### PR TITLE
feat(playnite): add setting to keep Playnite games running after session end

### DIFF
--- a/src/config_playnite.cpp
+++ b/src/config_playnite.cpp
@@ -223,6 +223,13 @@ namespace config {
       playnite.fullscreen_entry_enabled = to_bool(tmp);
     }
 
+    // Keep Playnite-managed apps running when a streaming session ends.
+    tmp.clear();
+    erase_take(vars, "playnite_keep_running_on_session_end", tmp);
+    if (!tmp.empty()) {
+      playnite.keep_running_on_session_end = to_bool(tmp);
+    }
+
     // lists (already cleared by reset above, but explicit for clarity)
     playnite.sync_categories_meta.clear();
     playnite.sync_categories.clear();

--- a/src/config_playnite.h
+++ b/src/config_playnite.h
@@ -69,6 +69,12 @@ namespace config {
     // When enabled, Sunshine maintains a "Playnite (Fullscreen)" entry in apps.json
     // that launches Playnite in fullscreen/desktop mode via the helper.
     bool fullscreen_entry_enabled = false;
+
+    // When true, ending a streaming session (Moonlight "cancel") leaves a Playnite-
+    // managed app running on the host instead of terminating it. Non-Playnite apps
+    // and explicit close actions (tray, Web UI, Moonlight Terminate entry) are
+    // unaffected.
+    bool keep_running_on_session_end = false;
   };
 
   extern playnite_t playnite;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2719,7 +2719,7 @@ namespace nvhttp {
     rtsp_stream::terminate_sessions();
 
     if (proc::proc.running() > 0) {
-      proc::proc.terminate();
+      proc::proc.terminate(false, true, false, true /* is_session_end */);
     }
     // The config needs to be reverted regardless of whether "proc::proc.terminate()" was called or not.
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -2179,7 +2179,7 @@ namespace proc {
 #endif
   }
 
-  void proc_t::terminate(bool immediate, bool needs_refresh, bool skip_display_revert) {
+  void proc_t::terminate(bool immediate, bool needs_refresh, bool skip_display_revert, bool is_session_end) {
     std::error_code ec;
     const bool had_active_app = _app_id > 0;
     placebo = false;
@@ -2188,10 +2188,45 @@ namespace proc {
     _lossless_should_start_support = false;
     stop_lossless_scaling_support();
 #endif
+    // When a streaming session ends (Moonlight "cancel") and the configured policy is
+    // to keep Playnite-managed apps running, detach the child process handles instead
+    // of killing them. The rest of teardown (undo_cmds, display revert, state reset,
+    // virtual display cleanup) still runs as normal.
+    const bool detach_playnite_app_for_session_end = is_session_end
+      && config::playnite.keep_running_on_session_end
+      && had_active_app
+      && !_app.playnite_id.empty();
     // For Playnite-managed apps, request a graceful stop via Playnite first
     std::chrono::seconds remaining_timeout = _app.exit_timeout;
 #ifdef _WIN32
-    if (had_active_app && !_app.playnite_id.empty()) {
+    if (detach_playnite_app_for_session_end) {
+      BOOST_LOG(info) << "Session ended; detaching Playnite app '" << _app.name
+                      << "' so it keeps running (playnite_keep_running_on_session_end=enabled).";
+      // The process group is a Windows job object created with
+      // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE (see boost_process_shim.h). Closing the
+      // job handle — which group::detach() and the group destructor both do —
+      // would kill the launcher and the game along with it. Clear the kill-on-close
+      // flag first so the processes outlive the handle close.
+      if (_process_group) {
+        HANDLE job = _process_group.native_handle();
+        if (job) {
+          JOBOBJECT_EXTENDED_LIMIT_INFORMATION info {};
+          info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+          if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &info, sizeof(info))) {
+            BOOST_LOG(warning) << "Failed to clear JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE; "
+                                  "app may be killed when handle closes. GetLastError="
+                               << GetLastError();
+          }
+        }
+        _process_group.detach();
+      }
+      if (_process.valid()) {
+        _process.detach();
+      }
+      // IPC teardown still runs to match status-quo Playnite session cleanup;
+      // only the game/launcher kill is skipped.
+      platf::playnite::stop_client_for_session();
+    } else if (had_active_app && !_app.playnite_id.empty()) {
       bool should_request_playnite_stop = true;
       try {
         if (_process && !_process.running() && _process.native_exit_code() == 0) {
@@ -2218,8 +2253,12 @@ namespace proc {
       platf::playnite::stop_client_for_session();
     }
 #endif
-    // Regardless, ensure process group is terminated (graceful then forceful with remaining timeout)
-    terminate_process_group(_process, _process_group, remaining_timeout);
+    // Regardless, ensure process group is terminated (graceful then forceful with remaining timeout).
+    // Exception: when detaching a Playnite app at session end, handles were already detached
+    // above so the processes continue running outside of Sunshine's control.
+    if (!detach_playnite_app_for_session_end) {
+      terminate_process_group(_process, _process_group, remaining_timeout);
+    }
     _process = bp::child();
     _process_group = bp::group();
 

--- a/src/process.h
+++ b/src/process.h
@@ -189,7 +189,7 @@ namespace proc {
     bp::environment get_env();
     void resume();
     void pause();
-    void terminate(bool immediate = false, bool needs_refresh = true, bool skip_display_revert = false);
+    void terminate(bool immediate = false, bool needs_refresh = true, bool skip_display_revert = false, bool is_session_end = false);
     bool last_run_app_frame_gen_limiter_fix() const;
 
     // Hot-update app list and environment without disrupting a running app

--- a/src_assets/common/assets/web/configs/tabs/Playnite.vue
+++ b/src_assets/common/assets/web/configs/tabs/Playnite.vue
@@ -405,6 +405,16 @@
                 desc="playnite.focus_exit_on_first_help"
               />
             </div>
+            <div class="md:col-span-2">
+              <Checkbox
+                v-model="config.playnite_keep_running_on_session_end"
+                id="playnite_keep_running_on_session_end"
+                :default="store.defaults.playnite_keep_running_on_session_end"
+                :localePrefix="'playnite'"
+                label="playnite.keep_running_on_session_end"
+                desc="playnite.keep_running_on_session_end_help"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -1464,6 +1474,10 @@ function resetLaunchSection() {
   store.updateOption('playnite_focus_attempts', d.playnite_focus_attempts);
   store.updateOption('playnite_focus_timeout_secs', d.playnite_focus_timeout_secs);
   store.updateOption('playnite_focus_exit_on_first', d.playnite_focus_exit_on_first);
+  store.updateOption(
+    'playnite_keep_running_on_session_end',
+    d.playnite_keep_running_on_session_end,
+  );
   notify('success', (t('playnite.reset_done') as any) || 'Section reset to defaults.');
 }
 

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -800,6 +800,8 @@
     "focus_timeout_secs_help": "How long auto-focus runs while re-applying focus (0 to disable).",
     "focus_exit_on_first": "Stop auto-focus after first successful focus",
     "focus_exit_on_first_help": "Stop auto-focus after the first success; otherwise, re-apply until attempts or timeout elapse.",
+    "keep_running_on_session_end": "Keep Playnite games running after session ends",
+    "keep_running_on_session_end_help": "When a streaming session ends, leave the Playnite-launched game running on the host instead of terminating it. Explicit close actions (tray, Web UI, Moonlight Terminate entry) still terminate the game.",
     "diagnostic_not_installed": "Playnite plugin is not installed in the Extensions directory.",
     "diagnostic_not_running": "Playnite is not running. Launch it to resume syncing.",
     "section_auto_sync": "Auto-sync",

--- a/src_assets/common/assets/web/public/assets/locale/en_GB.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_GB.json
@@ -960,6 +960,8 @@
     "focus_timeout_secs_help": "How long auto-focus runs while re-applying focus (0 to disable).",
     "focus_exit_on_first": "Stop auto-focus after first successful focus",
     "focus_exit_on_first_help": "Stop auto-focus after the first success; otherwise, re-apply until attempts or timeout elapse.",
+    "keep_running_on_session_end": "Keep Playnite games running after session ends",
+    "keep_running_on_session_end_help": "When a streaming session ends, leave the Playnite-launched game running on the host instead of terminating it. Explicit close actions (tray, Web UI, Moonlight Terminate entry) still terminate the game.",
     "diagnostic_not_installed": "Playnite plugin is not installed in the Extensions directory.",
     "diagnostic_not_running": "Playnite is not running. Launch it to resume syncing.",
     "section_auto_sync": "Auto-sync",

--- a/src_assets/common/assets/web/public/assets/locale/en_US.json
+++ b/src_assets/common/assets/web/public/assets/locale/en_US.json
@@ -1045,6 +1045,8 @@
     "focus_timeout_secs_help": "How long auto-focus runs while re-applying focus (0 to disable).",
     "focus_exit_on_first": "Stop auto-focus after first successful focus",
     "focus_exit_on_first_help": "Stop auto-focus after the first success; otherwise, re-apply until attempts or timeout elapse.",
+    "keep_running_on_session_end": "Keep Playnite games running after session ends",
+    "keep_running_on_session_end_help": "When a streaming session ends, leave the Playnite-launched game running on the host instead of terminating it. Explicit close actions (tray, Web UI, Moonlight Terminate entry) still terminate the game.",
     "diagnostic_not_installed": "Playnite plugin is not installed in the Extensions directory.",
     "diagnostic_not_running": "Playnite is not running. Launch it to resume syncing.",
     "section_auto_sync": "Auto-sync",

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -187,6 +187,7 @@ const defaultGroups = [
       playnite_focus_timeout_secs: 15,
       playnite_focus_exit_on_first: false,
       playnite_fullscreen_entry_enabled: false,
+      playnite_keep_running_on_session_end: false,
       playnite_sync_categories: [] as Array<{ id: string; name: string }>,
       playnite_sync_plugins: [] as Array<{ id: string; name: string }>,
       playnite_exclude_categories: [] as Array<{ id: string; name: string }>,
@@ -526,6 +527,7 @@ export const useConfigStore = defineStore('config', () => {
       'playnite_autosync_remove_uninstalled',
       'playnite_focus_exit_on_first',
       'playnite_fullscreen_entry_enabled',
+      'playnite_keep_running_on_session_end',
     ];
     // Extend boolean normalization to cover RTSS enable flag
     const otherBoolKeys = [


### PR DESCRIPTION
New 'playnite_keep_running_on_session_end' toggle (Settings -> Playnite -> Launch Behavior). When enabled, Moonlight's 'Quit Game' ends the streaming session but leaves the Playnite-launched game running on the host, so the user can keep playing directly on the PC.

Implementation detaches the launcher/game process group in proc_t::terminate() only for Moonlight's /cancel endpoint (is_session_end=true). Clears JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE on the job object before closing the handle so the processes survive. All other terminate paths (tray close, Web UI close, Moonlight Terminate app, Sunshine shutdown, config reload) are unchanged.

Non-Playnite apps and all explicit close actions still terminate the game.

Co-authored-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>