### PR TITLE
fix(hdr): latch HDR colorspace so a transient SDR reinit can't downgrade the stream

### DIFF
--- a/src/video.cpp
+++ b/src/video.cpp
@@ -787,6 +787,9 @@ namespace video {
     config_t config;
     int frame_nr;
     void *channel_data;
+    // Sticky "this session has established HDR" flag, persists across capture
+    // reinits so a transient SDR display reading cannot downgrade an HDR stream.
+    bool hdr_latched = false;
   };
 
   struct sync_session_t {
@@ -3013,7 +3016,7 @@ namespace video {
     };
   }
 
-  std::unique_ptr<platf::encode_device_t> make_encode_device(platf::display_t &disp, const encoder_t &encoder, const config_t &config) {
+  std::unique_ptr<platf::encode_device_t> make_encode_device(platf::display_t &disp, const encoder_t &encoder, const config_t &config, bool *hdr_latch = nullptr) {
     std::unique_ptr<platf::encode_device_t> result;
 
     bool hdr_display = disp.is_hdr();
@@ -3024,6 +3027,25 @@ namespace video {
     const bool rtx_hdr_stream = config.rtx_hdr_active;
     hdr_display = hdr_display || rtx_hdr_stream;
 #endif
+
+    // HDR colorspace latch. A virtual display created for an HDR session can briefly
+    // re-enumerate as SDR during a capture reinit (the double-refresh / HDR-profile mode
+    // change that happens ~1s into a session momentarily drops the output to G22 8-bit).
+    // Without this guard the encoder gets rebuilt for an 8-bit SDR colorspace mid-session
+    // and streams SDR frames to an HDR client, which faults the client decoder
+    // ("decoder reported error") and tears the session down. Once an HDR-requested session
+    // has actually established HDR, keep the HDR colorspace for the rest of the session so a
+    // momentary SDR reading during a reinit can no longer downgrade the wire colorspace.
+    // (Genuinely-SDR sources never latch, because hdr_display is never true for them.)
+    if (config.dynamicRange > 0 && hdr_latch) {
+      if (hdr_display) {
+        *hdr_latch = true;
+      } else if (*hdr_latch) {
+        BOOST_LOG(info) << "Display momentarily reported SDR during reinit; keeping HDR colorspace for this HDR session.";
+        hdr_display = true;
+      }
+    }
+
     auto colorspace = colorspace_from_client_config(config, hdr_display);
 
     platf::pix_fmt_e pix_fmt;
@@ -3078,7 +3100,7 @@ namespace video {
 
     encode_session.ctx = &ctx;
 
-    auto encode_device = make_encode_device(*disp, encoder, ctx.config);
+    auto encode_device = make_encode_device(*disp, encoder, ctx.config, &ctx.hdr_latched);
     if (!encode_device) {
       return std::nullopt;
     }
@@ -3385,6 +3407,10 @@ namespace video {
 
     int frame_nr = 1;
 
+    // Sticky "this session has established HDR" flag, persists across capture
+    // reinits so a transient SDR display reading cannot downgrade an HDR stream.
+    bool hdr_latched = false;
+
     auto touch_port_event = mail->event<input::touch_port_t>(mail::touch_port);
     auto hdr_event = mail->event<hdr_info_t>(mail::hdr);
 
@@ -3415,7 +3441,7 @@ namespace video {
       }
       auto &encoder = *enc_ptr;
 
-      auto encode_device = make_encode_device(*display, encoder, config);
+      auto encode_device = make_encode_device(*display, encoder, config, &hdr_latched);
       if (!encode_device) {
         return;
       }


### PR DESCRIPTION
### Problem
A virtual display created for an HDR session briefly re-enumerates as SDR during a capture reinit — the double-refresh / HDR-profile mode change ~1s into a session momentarily drops the output to G22 8-bit. `make_encode_device` re-reads `is_hdr()` on every reinit, so the encoder was rebuilt for an 8-bit SDR colorspace mid-session and streamed SDR frames to an HDR client. That faults the client decoder (`"decoder reported error"`) and tears the session down.

The legacy `dd_wa_hdr_toggle` workaround that previously masked this was removed in the v1.14 display refactor; this covers the capture-side path that the display-device config-apply does not.

### Fix
Latch the established-HDR state per session (a field on `sync_session_ctx_t` for sync capture, a local in the async capture loop) so that once an HDR-requested session has actually established HDR, a momentary `is_hdr() == false` during a reinit can no longer downgrade the wire colorspace. Genuinely-SDR sources never latch because `hdr_display` is never true for them.

Single-file change in `src/video.cpp` (+29/-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
