### PR TITLE
fix(apps): restore legacy app ordering toggles for client compatibility

### DIFF
--- a/src/confighttp.cpp
+++ b/src/confighttp.cpp
@@ -2562,6 +2562,7 @@ namespace confighttp {
         input_tree.contains("virtual_display_layout") ||
         input_tree.contains("config_overrides") ||
         input_tree.contains("prefer_10bit_sdr") ||
+        input_tree.contains("enable_legacy_ordering") ||
         input_tree.contains("allow_client_commands") ||
         input_tree.contains("perm") ||
         input_tree.contains("do") ||
@@ -2576,7 +2577,7 @@ namespace confighttp {
       std::string name = input_tree.value("name", "");
       std::string display_mode = input_tree.value("display_mode", "");
       std::string output_name_override = input_tree.value("output_name_override", "");
-      bool enable_legacy_ordering = true;
+      bool enable_legacy_ordering = input_tree.value("enable_legacy_ordering", true);
       bool allow_client_commands = input_tree.value("allow_client_commands", true);
       bool always_use_virtual_display = input_tree.value("always_use_virtual_display", false);
       std::optional<bool> prefer_10bit_sdr;

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2509,7 +2509,7 @@ namespace nvhttp {
           visible_apps.push_back(&app);
         }
 
-        const bool enable_legacy_ordering = true;
+        const bool enable_legacy_ordering = config::sunshine.legacy_ordering && named_cert_p->enable_legacy_ordering;
         size_t bits = 0;
         if (enable_legacy_ordering && !visible_apps.empty()) {
           bits = zwpad::pad_width_for_count(visible_apps.size());

--- a/src_assets/common/assets/web/configs/tabs/Advanced.vue
+++ b/src_assets/common/assets/web/configs/tabs/Advanced.vue
@@ -31,6 +31,12 @@ const config = store.config;
     />
 
     <ConfigFieldRenderer
+      v-model="config.legacy_ordering"
+      setting-key="legacy_ordering"
+      class="mb-3"
+    />
+
+    <ConfigFieldRenderer
       v-model="config.ignore_encoder_probe_failure"
       setting-key="ignore_encoder_probe_failure"
       class="mb-6"

--- a/src_assets/common/assets/web/pin.html
+++ b/src_assets/common/assets/web/pin.html
@@ -232,6 +232,16 @@
                 </div>
               </div>
 
+              <!-- Enable legacy ordering -->
+              <Checkbox
+                class="mb-3"
+                id="enable_legacy_ordering"
+                label="pin.enable_legacy_ordering"
+                desc="pin.enable_legacy_ordering_desc"
+                v-model="client.editEnableLegacyOrdering"
+                default="true"
+              ></Checkbox>
+
               <!-- Allow client commands -->
               <Checkbox
                 class="mb-3"
@@ -689,6 +699,7 @@
           client.editPerm = client.perm;
           client.editName = client.name;
           client.editAllowClientCommands = client.allow_client_commands;
+          client.editEnableLegacyOrdering = client.enable_legacy_ordering;
           client.editAlwaysUseVirtualDisplay = client.always_use_virtual_display;
           client.editDisplayMode = client.display_mode;
           client.edit_do = JSON.parse(JSON.stringify(client.do || []));
@@ -704,6 +715,7 @@
           client.editName = client.name;
           client.editDisplayMode = client.display_mode;
           client.editAllowClientCommands = client.allow_client_commands;
+          client.editEnableLegacyOrdering = client.enable_legacy_ordering;
           client.editAlwaysUseVirtualDisplay = client.always_use_virtual_display;
         },
         saveClient(client) {
@@ -714,6 +726,7 @@
             name: client.editName,
             display_mode: client.editDisplayMode.trim(),
             allow_client_commands: client.editAllowClientCommands,
+            enable_legacy_ordering: client.editEnableLegacyOrdering,
             always_use_virtual_display: client.editAlwaysUseVirtualDisplay,
             perm: client.editPerm & permissionMapping._all,
             do: client.edit_do.reduce((filtered, { cmd: _cmd, elevated }) => {
@@ -861,6 +874,7 @@
                     undo,
                     allow_client_commands,
                     always_use_virtual_display,
+                    enable_legacy_ordering,
                   }) => {
                     const permInt = parseInt(perm, 10);
                     return {
@@ -874,6 +888,7 @@
                       undo,
                       allow_client_commands,
                       always_use_virtual_display,
+                      enable_legacy_ordering,
                     };
                   },
                 );


### PR DESCRIPTION
# Restore Legacy App Ordering Configuration (Global + Per-Client)

## Summary

This PR restores both the global configuration and per-client settings for **Legacy App Ordering** (`legacy_ordering`), which were inadvertently hardcoded to `true` in v1.17.0.

This allows legacy ordering to be selectively disabled for clients that require unmodified application names, such as the Moonlight CLI and MoonDeck.

## Problem

When **Legacy App Ordering** is enabled, the host prepends hidden Unicode zero-width characters (`\u200B` and `\u200C`) to application names returned by the `/applist` endpoint. These invisible characters preserve a stable custom application order for legacy Moonlight GUI clients.

However, command-line clients such as the Moonlight CLI perform **literal string matching** against the application names returned by `/applist`. Because the hidden characters are not stripped, application lookup fails.

Example:

```text
Requested: "Steam"
Returned:  "\u200B\u200CSteam"
```

As a result, the CLI hangs on:

```text
Loading app list...
```

before eventually reporting that the application was not found.

Since **MoonDeck** uses the Moonlight CLI internally, this regression also prevents MoonDeck from launching streams.

## Solution

This PR restores the ability to enable or disable legacy ordering both globally and on a per-client basis.

### C++ Backend

* Restored parsing and persistence of `enable_legacy_ordering` in `src/confighttp.cpp`.
* Replaced the hardcoded value in `src/nvhttp.cpp`:

```cpp
const bool enable_legacy_ordering =
    config::sunshine.legacy_ordering &&
    named_cert_p->enable_legacy_ordering;
```

This combines the global configuration with the per-client override.

### Web UI

* Restored the **"App ordering for legacy clients"** toggle under **Configuration → Advanced** (`Advanced.vue`).
* Restored the **"Enable legacy ordering"** checkbox in the **Client Management** edit dialog (`pin.html`).
* Reconnected the Vue state handlers for both settings.

## Testing

### Functional Verification

1. Open **Client Management**.
2. Disable **Enable legacy ordering** for the Moonlight CLI client.
3. Run:

```bash
moonlight stream <host_ip> <app_name>
```

### Expected Result

* The Moonlight CLI receives application names without hidden zero-width characters.
* Application lookup succeeds immediately.
* Streaming launches successfully.
* MoonDeck functionality is restored.
