### PR TITLE
fix(pacer): fold FEC into the pacing-cap clamp floor

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -2003,17 +2003,20 @@ namespace stream {
         if (config::stream.pacing_max_bitrate_kbps > 0) {
           pacing_bps = (size_t) config::stream.pacing_max_bitrate_kbps * 1000ull;
 
-          // Never pace below the session's negotiated bitrate: a cap under the encoder's
-          // output rate makes the sender permanently slower than the encoder, so the packet
-          // queue (and stream latency) grows without bound. Clamp to ~110% of the stream
-          // bitrate, re-evaluated per frame since the ABR endpoint can raise it mid-session.
-          size_t session_floor_bps = (size_t) session->config.monitor.bitrate * 1000ull * 110 / 100;
+          // Never pace below the encoder's real on-wire rate: a cap under it makes the
+          // sender permanently slower than the encoder, so the packet queue (and stream
+          // latency) grows without bound. monitor.bitrate is the FEC-stripped video rate,
+          // so the floor must fold FEC back in like the auto-derive path below does —
+          // 110% of video is only ~0.9x of on-wire at 20% FEC. Floor at the same
+          // FEC-folded 1.3x expression, re-evaluated per frame since the ABR endpoint
+          // can raise the bitrate (and FEC vary per frame) mid-session.
+          size_t session_floor_bps = (size_t) session->config.monitor.bitrate * 1000ull * 13 / 10 * (100 + fecPercentage) / 100;
           if (pacing_bps < session_floor_bps) {
             static std::atomic_flag pacing_clamp_warned;
             if (!pacing_clamp_warned.test_and_set()) {
               BOOST_LOG(warning) << "pacing_max_bitrate_kbps ("sv << config::stream.pacing_max_bitrate_kbps
-                                 << " kbps) is below the negotiated stream bitrate ("sv << session->config.monitor.bitrate
-                                 << " kbps); clamping the pacer to 110% of the stream bitrate"sv;
+                                 << " kbps) is below the stream's on-wire rate (negotiated "sv << session->config.monitor.bitrate
+                                 << " kbps video plus FEC); clamping the pacer to "sv << session_floor_bps / 1000 << " kbps"sv;
             }
             pacing_bps = session_floor_bps;
           }


### PR DESCRIPTION
### Problem

The `pacing_max_bitrate_kbps` clamp floor in `videoBroadcastThread` (src/stream.cpp) prevents an operator-set pacing cap from starving the sender below the encoder rate — but it computes the floor from **video** bitrate only, ignoring FEC and packet-header expansion:

```cpp
size_t session_floor_bps = (size_t) session->config.monitor.bitrate * 1000ull * 110 / 100;  // 110% of video
```

`monitor.bitrate` is the FEC-stripped video rate. The actual on-wire rate is higher: at the default 20% FEC plus header expansion it's roughly **1.23x** the video bitrate. So a "110% of video" floor is only ~0.9x of the real on-wire rate — the sender is clamped *below* what the encoder+FEC actually produce, pacing debt accrues every frame, and the packet mailbox (and stream latency) drifts upward without bound. This is the same drift-to-overflow failure that the auto-derive path already accounts for a few lines below (it folds FEC in via `(100 + fecPercentage)` and a ~1.3x headroom).

### Fix

Floor the operator cap using the **same FEC-folded expression the auto-derive path uses**, re-evaluated per frame (both the ABR bitrate and per-frame `fecPercentage` can change mid-session, including the `fecPercentage = 0` giant-frame path):

```cpp
size_t session_floor_bps = (size_t) session->config.monitor.bitrate * 1000ull * 13 / 10 * (100 + fecPercentage) / 100;
```

The warning message is updated to report the actual clamp target.

### Impact

Latent unless `pacing_max_bitrate_kbps` is set below ~1.3x the video bitrate; when it is, this converts a silent unbounded-latency-growth mode into a correct clamp. `fecPercentage` is already in scope at this point (declared earlier in the same function), including its `= 0` reset on the single-giant-frame path, so the folded floor degrades cleanly to 1.3x when FEC is disabled.
