### PR TITLE
feat(playnite): serve last played and playtime to clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,12 @@ jobs:
       release_version: ${{ needs.release-candidate.outputs.release_version || '0.0.0' }}
       release_tag: ${{ needs.release-candidate.outputs.tag_name }}
       symbol_product_name: Vibepollo
-      publish_symbols: ${{ needs.release-candidate.outputs.should_release == 'true' }}
+      # This fork has neither a SignPath subscription nor a symbol-server token, and both gates
+      # hard-fail the build when required but unconfigured. Releases here ship unsigned.
+      publish_symbols: false
       symbol_release_draft: true
       symbol_release_prefix: polo
-      require_signpath_signing: ${{ needs.release-candidate.outputs.should_release == 'true' }}
+      require_signpath_signing: false
       require_truehdr_runtime: ${{ needs.release-candidate.outputs.should_release == 'true' }}
     secrets:
       symbol_token: ${{ secrets.SYMBOL_TOKEN }}

--- a/cmake/prep/build_version.cmake
+++ b/cmake/prep/build_version.cmake
@@ -18,8 +18,8 @@ endif()
 
 # Allow forks / CI to override which GitHub repo is used for update checks.
 # Cache variables can be provided via -DSUNSHINE_REPO_OWNER=... or -DSUNSHINE_REPO_NAME=...
-set(SUNSHINE_REPO_OWNER "Nonary" CACHE STRING "GitHub repo owner for update checks")
-set(SUNSHINE_REPO_NAME "vibepollo" CACHE STRING "GitHub repo name for update checks")
+set(SUNSHINE_REPO_OWNER "DanieleS" CACHE STRING "GitHub repo owner for update checks")
+set(SUNSHINE_REPO_NAME "Vibepollo" CACHE STRING "GitHub repo name for update checks")
 
 # Allow environment variables to override the cache values (useful in CI)
 if(DEFINED ENV{SUNSHINE_REPO_OWNER})
@@ -30,7 +30,7 @@ if(DEFINED ENV{SUNSHINE_REPO_NAME})
 endif()
 
 # Try to infer owner/name from the clone URL when available and the defaults are still in use
-if(DEFINED GITHUB_CLONE_URL AND (SUNSHINE_REPO_OWNER STREQUAL "Nonary" OR SUNSHINE_REPO_NAME STREQUAL "vibepollo"))
+if(DEFINED GITHUB_CLONE_URL AND (SUNSHINE_REPO_OWNER STREQUAL "DanieleS" OR SUNSHINE_REPO_NAME STREQUAL "Vibepollo"))
     string(REGEX MATCH "github.com[:/]+([^/]+)/([^/]+)(\\.git)?$" _match "${GITHUB_CLONE_URL}")
     if(_match)
         set(SUNSHINE_REPO_OWNER "${CMAKE_MATCH_1}")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3973,6 +3973,27 @@ They appear in the Frame Limiter section of the settings UI.
     </tr>
 </table>
 
+### playnite_exclude_hidden_games
+
+<table>
+    <tr>
+        <td>Description</td>
+        <td>
+            Controls whether games flagged as hidden in Playnite are auto-synced.
+            When <code>true</code>, hidden games are never selected, and auto-synced entries are removed once the game is hidden in Playnite.
+            Manually added games are not affected.
+        </td>
+    </tr>
+    <tr>
+        <td>Default</td>
+        <td>@code{}true@endcode</td>
+    </tr>
+    <tr>
+        <td>Example</td>
+        <td>@code{}playnite_exclude_hidden_games = false@endcode</td>
+    </tr>
+</table>
+
 ### playnite_sync_plugins
 
 <table>

--- a/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
+++ b/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
@@ -1277,6 +1277,17 @@ function Get-IconPath {
   return ''
 }
 
+function Get-BackgroundPath {
+  param([object]$Game)
+  try {
+    if ($Game.BackgroundImage) {
+      return $PlayniteApi.Database.GetFullFilePath($Game.BackgroundImage)
+    }
+  }
+  catch {}
+  return ''
+}
+
 function Get-PlayniteGames {
   if (-not $PlayniteApi) { return @() }
   $catMap = Get-CategoryNamesMap
@@ -1307,6 +1318,7 @@ function Get-PlayniteGames {
     try { if ($g.LastActivity) { $lastPlayed = ([DateTime]$g.LastActivity).ToString('o') } } catch {}
     $boxArt = Get-BoxArtPath -Game $g
     $icon = Get-IconPath -Game $g
+    $background = Get-BackgroundPath -Game $g
     # Determine installed state explicitly; fallback to InstallDirectory when IsInstalled is unavailable
     $installed = $false
     try {
@@ -1333,6 +1345,7 @@ function Get-PlayniteGames {
       lastPlayed      = $lastPlayed
       boxArtPath      = $boxArt
       iconPath        = $icon
+      backgroundPath  = $background
       installed       = $installed
       tags            = @() # TODO: fill from $g.TagIds if needed
       description     = $description

--- a/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
+++ b/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
@@ -1325,6 +1325,8 @@ function Get-PlayniteGames {
       if ($null -ne $g.IsInstalled) { $installed = [bool]$g.IsInstalled }
       elseif ($g.InstallDirectory) { $installed = $true }
     } catch {}
+    $hidden = $false
+    try { if ($null -ne $g.Hidden) { $hidden = [bool]$g.Hidden } } catch {}
     $pluginId = ''
     try { if ($g.PluginId) { $pluginId = $g.PluginId.ToString() } } catch {}
     $pluginName = ''
@@ -1347,6 +1349,7 @@ function Get-PlayniteGames {
       iconPath        = $icon
       backgroundPath  = $background
       installed       = $installed
+      hidden          = $hidden
       tags            = @() # TODO: fill from $g.TagIds if needed
       description     = $description
       genres          = $genreNames

--- a/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
+++ b/plugins/playnite/SunshinePlaynite/SunshinePlaynite.psm1
@@ -1146,6 +1146,40 @@ function Get-CategoryNamesMap {
   return $map
 }
 
+# Build an id -> name map for a Playnite database field collection (Genres, Companies, ...).
+# Metadata Playnite enriches (e.g. via its IGDB add-on) is stored by id on the game and
+# resolved through these shared collections, exactly like categories.
+function Get-DbEntityNamesMap {
+  param([string]$Collection)
+  $map = @{}
+  try {
+    $db = $null
+    try { $db = $PlayniteApi.Database } catch {}
+    if (-not $db) { return $map }
+    $src = $null
+    try { $src = $db.$Collection } catch {}
+    if (-not $src) { return $map }
+    foreach ($e in $src) {
+      try { $map[$e.Id] = $e.Name } catch {}
+    }
+  } catch {}
+  return $map
+}
+
+# Resolve a game's list of ids against a names map into an array of display names.
+function Resolve-IdNames {
+  param($Ids, $Map)
+  $names = @()
+  try {
+    if ($Ids -and $Map) {
+      foreach ($id in $Ids) {
+        try { if ($Map.ContainsKey($id)) { $names += $Map[$id] } } catch {}
+      }
+    }
+  } catch {}
+  return $names
+}
+
 function Get-LibraryPluginMap {
   $map = @{}
   try {
@@ -1247,11 +1281,26 @@ function Get-PlayniteGames {
   if (-not $PlayniteApi) { return @() }
   $catMap = Get-CategoryNamesMap
   $pluginMap = Get-LibraryPluginMap
+  $genreMap = Get-DbEntityNamesMap -Collection 'Genres'
+  $companyMap = Get-DbEntityNamesMap -Collection 'Companies'
   $games = @()
   foreach ($g in $PlayniteApi.Database.Games) {
     $act = Get-GameActionInfo -Game $g
     $catNames = @()
     if ($g.CategoryIds) { foreach ($cid in $g.CategoryIds) { if ($catMap.ContainsKey($cid)) { $catNames += $catMap[$cid] } } }
+    # Metadata Playnite already enriched (IGDB and friends). Resolved here so the client can
+    # show it without ever talking to a metadata provider itself.
+    $genreNames = @(Resolve-IdNames -Ids $g.GenreIds -Map $genreMap)
+    $developerNames = @(Resolve-IdNames -Ids $g.DeveloperIds -Map $companyMap)
+    $publisherNames = @(Resolve-IdNames -Ids $g.PublisherIds -Map $companyMap)
+    $description = ''
+    try { if ($g.Description) { $description = [string]$g.Description } } catch {}
+    $releaseDate = ''
+    try { if ($g.ReleaseDate) { $releaseDate = $g.ReleaseDate.ToString() } } catch {}
+    $communityScore = $null
+    try { if ($null -ne $g.CommunityScore) { $communityScore = [int]$g.CommunityScore } } catch {}
+    $criticScore = $null
+    try { if ($null -ne $g.CriticScore) { $criticScore = [int]$g.CriticScore } } catch {}
     $playtimeMin = 0
     try { if ($g.Playtime) { $playtimeMin = [int]([double]$g.Playtime / 60.0) } } catch {}
     $lastPlayed = ''
@@ -1286,6 +1335,13 @@ function Get-PlayniteGames {
       iconPath        = $icon
       installed       = $installed
       tags            = @() # TODO: fill from $g.TagIds if needed
+      description     = $description
+      genres          = $genreNames
+      developers      = $developerNames
+      publishers      = $publisherNames
+      releaseDate     = $releaseDate
+      communityScore  = $communityScore
+      criticScore     = $criticScore
     }
   }
   Write-Log "Collected $($games.Count) games"

--- a/plugins/playnite/SunshinePlaynite/extension.yaml
+++ b/plugins/playnite/SunshinePlaynite/extension.yaml
@@ -1,7 +1,7 @@
 Id: Sunshine.Playnite.PowerShell
 Name: Sunshine Playnite Connector
 Author: Nonary
-Version: 0.4.7
+Version: 0.4.8
 Module: SunshinePlaynite.psm1
 Type: Script
 Description: Adds two-way communication between Vibepollo and Playnite, allowing you to launch games from Playnite and have Vibepollo automatically start streaming them.

--- a/release_notes/1.18.1.md
+++ b/release_notes/1.18.1.md
@@ -2,6 +2,9 @@
 
 Notice: Vibepollo may trigger false-positive antivirus alerts.
 
+Notice: builds from this fork are not code-signed, so Windows SmartScreen reports an unknown
+publisher on first run. Choose "More info" then "Run anyway" to continue.
+
 This release contains everything in Vibepollo 1.18.0 plus the changes below.
 
 ## Changes

--- a/release_notes/1.18.1.md
+++ b/release_notes/1.18.1.md
@@ -1,0 +1,13 @@
+# Vibepollo 1.18.1 - 2026-07-14
+
+Notice: Vibepollo may trigger false-positive antivirus alerts.
+
+This release contains everything in Vibepollo 1.18.0 plus the changes below.
+
+## Changes
+- Playnite now passes the metadata it has already enriched (genres, developers, publishers, release date, community and critic scores, description) straight through to clients. Vibepollo never queries a metadata provider itself. The data is served by a new `GET /appmetadata` endpoint, leaving the Moonlight app-list hot path untouched.
+- Playnite background/hero artwork is passed through as well, exposed as `has_background` in `/appmetadata` and served by a new `GET /appbackground?appid=<id>` endpoint.
+- `serverinfo` now reports `currentgamename` alongside `currentgame` and `currentgameuuid`, so a client can name the running app without fetching and searching the whole app list.
+
+## Fixes
+- Update checks, the dashboard, and the changelog now look at this fork's releases instead of the repository it was forked from. Previously a build from this fork announced upstream's releases as its own and offered to install upstream's binaries over itself.

--- a/release_notes/1.18.2.md
+++ b/release_notes/1.18.2.md
@@ -1,0 +1,11 @@
+# Vibepollo 1.18.2 - 2026-07-16
+
+Notice: Vibepollo may trigger false-positive antivirus alerts.
+
+Notice: builds from this fork are not code-signed, so Windows SmartScreen reports an unknown
+publisher on first run. Choose "More info" then "Run anyway" to continue.
+
+This release contains everything in Vibepollo 1.18.1 plus the changes below.
+
+## Changes
+- Games hidden in Playnite are no longer auto-synced, and an auto-synced game is removed once you hide it in Playnite. Manually added games are never affected. The behaviour is controlled by the new `playnite_exclude_hidden_games` option (enabled by default) and by the "Skip games hidden in Playnite" toggle in the Playnite tab. Requires the updated Playnite extension (0.4.8), which reports the hidden state; with an older extension no game is treated as hidden.

--- a/release_notes/1.18.2.md
+++ b/release_notes/1.18.2.md
@@ -1,4 +1,4 @@
-# Vibepollo 1.18.2 - 2026-07-16
+# Vibepollo 1.18.2 - 2026-07-19
 
 Notice: Vibepollo may trigger false-positive antivirus alerts.
 
@@ -9,3 +9,7 @@ This release contains everything in Vibepollo 1.18.1 plus the changes below.
 
 ## Changes
 - Games hidden in Playnite are no longer auto-synced, and an auto-synced game is removed once you hide it in Playnite. Manually added games are never affected. The behaviour is controlled by the new `playnite_exclude_hidden_games` option (enabled by default) and by the "Skip games hidden in Playnite" toggle in the Playnite tab. Requires the updated Playnite extension (0.4.8), which reports the hidden state; with an older extension no game is treated as hidden.
+
+## Fixes
+- Auto-synced games deleted from the Playnite library are now removed from the app list. Previously they were only removed when Playnite reported them as uninstalled, so a game removed from the library outright survived every sync, force sync included, and had to be cleared by resetting the synced games by hand.
+- Emptying the Playnite library is now reflected in the app list. Previously an empty library sent no game batches, and the last known library stayed cached and was reconciled against as if it were current.

--- a/src/config_playnite.cpp
+++ b/src/config_playnite.cpp
@@ -157,6 +157,11 @@ namespace config {
     if (!tmp.empty()) {
       playnite.autosync_remove_uninstalled = to_bool(tmp);
     }
+    tmp.clear();
+    erase_take(vars, "playnite_exclude_hidden_games", tmp);
+    if (!tmp.empty()) {
+      playnite.exclude_hidden_games = to_bool(tmp);
+    }
 
     // integers
     tmp.clear();

--- a/src/config_playnite.h
+++ b/src/config_playnite.h
@@ -58,6 +58,10 @@ namespace config {
     // uninstalled in Playnite.
     bool autosync_remove_uninstalled = true;
 
+    // When true, games flagged as hidden in Playnite are never auto-synced, and
+    // auto-synced apps whose games become hidden are removed.
+    bool exclude_hidden_games = true;
+
     // When true, only purge auto-synced games that no longer qualify
     // if there is a qualifying replacement to fill the slot. When false,
     // always purge games that no longer qualify, even if it leaves fewer

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3354,6 +3354,80 @@ namespace nvhttp {
     response->close_connection_after_response = true;
   }
 
+  /**
+   * @brief Serve Playnite-enriched per-app metadata as JSON, keyed by app UUID.
+   *
+   * This is additive to the Moonlight protocol: only apps that carry metadata (Playnite games)
+   * are listed, and clients that don't know the endpoint simply never call it. The applist
+   * hot-path is left untouched.
+   */
+  void appmetadata(resp_https_t response, req_https_t request) {
+    print_req<SunshineHTTPS>(request);
+
+    auto fg = util::fail_guard([&]() {
+      response->write(SimpleWeb::StatusCode::server_error_internal_server_error);
+      response->close_connection_after_response = true;
+    });
+
+    auto named_cert_p = get_verified_cert(request);
+    if (!has_client_perm(named_cert_p, PERM::_all_actions)) {
+      log_permission_denied("Get AppMetadata"sv, "List applications"sv, named_cert_p);
+      fg.disable();
+      response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+      response->close_connection_after_response = true;
+      return;
+    }
+
+    nlohmann::json root = nlohmann::json::object();
+    nlohmann::json apps = nlohmann::json::array();
+
+    for (const auto &app : proc::proc.get_apps()) {
+      const auto &meta = app.playnite_metadata;
+      if (!meta.present) {
+        continue;
+      }
+      nlohmann::json node = nlohmann::json::object();
+      node["uuid"] = app.uuid;
+      node["id"] = app.id;
+      node["name"] = app.name;
+      if (!app.playnite_id.empty()) {
+        node["playnite_id"] = app.playnite_id;
+      }
+      if (!meta.description.empty()) {
+        node["description"] = meta.description;
+      }
+      if (!meta.genres.empty()) {
+        node["genres"] = meta.genres;
+      }
+      if (!meta.developers.empty()) {
+        node["developers"] = meta.developers;
+      }
+      if (!meta.publishers.empty()) {
+        node["publishers"] = meta.publishers;
+      }
+      if (!meta.release_date.empty()) {
+        node["release_date"] = meta.release_date;
+      }
+      if (meta.community_score >= 0) {
+        node["community_score"] = meta.community_score;
+      }
+      if (meta.critic_score >= 0) {
+        node["critic_score"] = meta.critic_score;
+      }
+      apps.push_back(std::move(node));
+    }
+
+    root["apps"] = std::move(apps);
+
+    fg.disable();
+
+    const std::string body = root.dump();
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "application/json");
+    response->write(SimpleWeb::StatusCode::success_ok, body, headers);
+    response->close_connection_after_response = true;
+  }
+
   void getClipboard(resp_https_t response, req_https_t request) {
     print_req<SunshineHTTPS>(request);
 
@@ -3687,6 +3761,7 @@ namespace nvhttp {
       });
     };
     https_server.resource["^/appasset$"]["GET"] = appasset;
+    https_server.resource["^/appmetadata$"]["GET"] = appmetadata;
     https_server.resource["^/launch$"]["GET"] = [&host_audio, run_blocking_nvhttp](auto resp, auto req) {
       run_blocking_nvhttp([&host_audio, resp = std::move(resp), req = std::move(req)]() mutable {
         std::lock_guard lock {launch_request_mutex};

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3414,6 +3414,10 @@ namespace nvhttp {
       if (meta.critic_score >= 0) {
         node["critic_score"] = meta.critic_score;
       }
+      if (!meta.background_image_path.empty()) {
+        // The image itself is fetched separately via /appbackground?appid=<id>.
+        node["has_background"] = true;
+      }
       apps.push_back(std::move(node));
     }
 
@@ -3425,6 +3429,50 @@ namespace nvhttp {
     SimpleWeb::CaseInsensitiveMultimap headers;
     headers.emplace("Content-Type", "application/json");
     response->write(SimpleWeb::StatusCode::success_ok, body, headers);
+    response->close_connection_after_response = true;
+  }
+
+  /**
+   * @brief Serve a Playnite game's background/hero image as PNG, mirroring /appasset.
+   *
+   * Additive and optional: returns 404 when the app has no background, so clients can simply
+   * try it and fall back gracefully.
+   */
+  void appbackground(resp_https_t response, req_https_t request) {
+    print_req<SunshineHTTPS>(request);
+
+    auto fg = util::fail_guard([&]() {
+      response->write(SimpleWeb::StatusCode::server_error_internal_server_error);
+      response->close_connection_after_response = true;
+    });
+
+    auto named_cert_p = get_verified_cert(request);
+    if (!has_client_perm(named_cert_p, PERM::_all_actions)) {
+      log_permission_denied("Get AppBackground"sv, "List applications"sv, named_cert_p);
+      fg.disable();
+      response->write(SimpleWeb::StatusCode::client_error_unauthorized);
+      response->close_connection_after_response = true;
+      return;
+    }
+
+    auto args = request->parse_query_string();
+    const auto appid = get_arg(args, "appid", "0");
+    const auto appuuid = get_arg(args, "appuuid", "");
+    auto app_ctx = proc::proc.resolve_app(appid, appuuid);
+    std::string bg = app_ctx ? app_ctx->playnite_metadata.background_image_path : std::string();
+
+    fg.disable();
+
+    std::ifstream in(bg, std::ios::binary);
+    if (bg.empty() || !in.is_open()) {
+      response->write(SimpleWeb::StatusCode::client_error_not_found);
+      response->close_connection_after_response = true;
+      return;
+    }
+
+    SimpleWeb::CaseInsensitiveMultimap headers;
+    headers.emplace("Content-Type", "image/png");
+    response->write(SimpleWeb::StatusCode::success_ok, in, headers);
     response->close_connection_after_response = true;
   }
 
@@ -3762,6 +3810,7 @@ namespace nvhttp {
     };
     https_server.resource["^/appasset$"]["GET"] = appasset;
     https_server.resource["^/appmetadata$"]["GET"] = appmetadata;
+    https_server.resource["^/appbackground$"]["GET"] = appbackground;
     https_server.resource["^/launch$"]["GET"] = [&host_audio, run_blocking_nvhttp](auto resp, auto req) {
       run_blocking_nvhttp([&host_audio, resp = std::move(resp), req = std::move(req)]() mutable {
         std::lock_guard lock {launch_request_mutex};

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2322,10 +2322,14 @@ namespace nvhttp {
         }
         tree.put("root.currentgame", current_appid);
         tree.put("root.currentgameuuid", proc::proc.get_running_app_uuid());
+        // The name of the running app, so a client can say what is being played without having
+        // to fetch and search the whole app list. Clients that do not know this field ignore it.
+        tree.put("root.currentgamename", current_appid > 0 ? proc::proc.get_last_run_app_name() : "");
         tree.put("root.state", current_appid > 0 ? "SUNSHINE_SERVER_BUSY" : "SUNSHINE_SERVER_FREE");
       } else {
         tree.put("root.currentgame", 0);
         tree.put("root.currentgameuuid", "");
+        tree.put("root.currentgamename", "");
         tree.put("root.state", "SUNSHINE_SERVER_FREE");
       }
 

--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -3422,6 +3422,12 @@ namespace nvhttp {
       if (meta.critic_score >= 0) {
         node["critic_score"] = meta.critic_score;
       }
+      if (!meta.last_played.empty()) {
+        node["last_played"] = meta.last_played;
+      }
+      if (meta.playtime_minutes > 0) {
+        node["playtime_minutes"] = meta.playtime_minutes;
+      }
       if (!meta.background_image_path.empty()) {
         // The image itself is fetched separately via /appbackground?appid=<id>.
         node["has_background"] = true;

--- a/src/platform/windows/playnite_integration.cpp
+++ b/src/platform/windows/playnite_integration.cpp
@@ -869,7 +869,7 @@ namespace platf::playnite {
       int delete_after_days = std::max(0, config::playnite.autosync_delete_after_days);
       bool changed = false;
       std::size_t matched = 0;
-      platf::playnite::sync::autosync_reconcile(root, all, recentN, recent_age_days, delete_after_days, config::playnite.autosync_require_replacement, config::playnite.sync_all_installed, config::playnite.sync_categories, config::playnite.sync_plugins, config::playnite.exclude_categories, config::playnite.exclude_games, config::playnite.exclude_plugins, config::playnite.autosync_remove_uninstalled, changed, matched);
+      platf::playnite::sync::autosync_reconcile(root, all, recentN, recent_age_days, delete_after_days, config::playnite.autosync_require_replacement, config::playnite.sync_all_installed, config::playnite.sync_categories, config::playnite.sync_plugins, config::playnite.exclude_categories, config::playnite.exclude_games, config::playnite.exclude_plugins, config::playnite.autosync_remove_uninstalled, config::playnite.exclude_hidden_games, changed, matched);
       if (changed) {
         platf::playnite::sync::write_and_refresh_apps(root, config::stream.file_apps);
       }
@@ -1143,6 +1143,7 @@ namespace platf::playnite {
       j["name"] = g.name;
       j["categories"] = g.categories;
       j["installed"] = g.installed;
+      j["hidden"] = g.hidden;
       j["pluginId"] = g.plugin_id;
       j["pluginName"] = g.plugin_name;
       arr.push_back(std::move(j));

--- a/src/platform/windows/playnite_integration.cpp
+++ b/src/platform/windows/playnite_integration.cpp
@@ -383,6 +383,8 @@ namespace platf::playnite {
           last_plugins_.clear();
           new_snapshot_ = true;
           snapshot_markers_supported_ = false;
+          library_complete_ = false;
+          library_confirmed_empty_ = false;
         } catch (...) {}
         {
           std::scoped_lock lk(progress_mutex_);
@@ -418,6 +420,8 @@ namespace platf::playnite {
         std::scoped_lock lk(mutex_);
         new_snapshot_ = true;
         snapshot_markers_supported_ = false;
+        library_complete_ = false;
+        library_confirmed_empty_ = false;
       }
       {
         std::scoped_lock lk(progress_mutex_);
@@ -686,6 +690,8 @@ namespace platf::playnite {
             last_games_.clear();
             game_ids_.clear();
             new_snapshot_ = false;
+            // Accumulating again: what we hold is partial until SnapshotComplete says otherwise.
+            library_complete_ = false;
           }
           before = last_games_.size();
           for (const auto &g : msg.games) {
@@ -760,11 +766,23 @@ namespace platf::playnite {
         BOOST_LOG(debug) << "Playnite: library snapshot starting";
         std::scoped_lock lk(mutex_);
         snapshot_markers_supported_ = true;
+        // Clear here rather than on the first 'games' batch: an emptied library sends no batch at
+        // all, which used to leave the previous snapshot in place and reconcile against stale data.
+        last_games_.clear();
+        game_ids_.clear();
+        new_snapshot_ = false;
+        library_complete_ = false;
+        library_confirmed_empty_ = false;
       } else if (msg.type == MT::SnapshotComplete) {
         std::size_t total = 0;
         {
           std::scoped_lock lk(mutex_);
           snapshot_markers_supported_ = true;
+          library_complete_ = true;
+          // Only an explicit zero from the plugin proves the library is empty. If we accumulated
+          // nothing but the plugin claims games (or reports nothing at all), the batches went
+          // missing and purging everything against that would be destructive.
+          library_confirmed_empty_ = last_games_.empty() && msg.snapshot_games_count == 0;
           ++snapshot_generation_;
           total = last_games_.size();
         }
@@ -843,14 +861,19 @@ namespace platf::playnite {
 
       // Build all games snapshot and reconcile with apps.json via helper
       std::vector<platf::playnite::Game> all;
+      bool library_complete = false;
+      bool library_confirmed_empty = false;
       {
         std::scoped_lock lk(mutex_);
         all = last_games_;
+        library_complete = library_complete_;
+        library_confirmed_empty = library_confirmed_empty_;
       }
-      // An empty snapshot means "no data from Playnite" (client just started, or Playnite not
-      // running), not "the library is empty". Reconciling against it would purge auto apps whose
-      // last-played/installed evidence simply hasn't arrived.
-      if (all.empty()) {
+      // An empty snapshot usually means "no data from Playnite" (client just started, or Playnite
+      // not running), not "the library is empty". Reconciling against it would purge auto apps
+      // whose last-played/installed evidence simply hasn't arrived. The exception is a snapshot the
+      // plugin explicitly closed with a zero-game count: there the library really is empty.
+      if (all.empty() && !library_confirmed_empty) {
         BOOST_LOG(warning) << "Playnite sync skipped: no games in cached library snapshot";
         stats.error = "no library snapshot from Playnite";
         return stats;
@@ -869,7 +892,7 @@ namespace platf::playnite {
       int delete_after_days = std::max(0, config::playnite.autosync_delete_after_days);
       bool changed = false;
       std::size_t matched = 0;
-      platf::playnite::sync::autosync_reconcile(root, all, recentN, recent_age_days, delete_after_days, config::playnite.autosync_require_replacement, config::playnite.sync_all_installed, config::playnite.sync_categories, config::playnite.sync_plugins, config::playnite.exclude_categories, config::playnite.exclude_games, config::playnite.exclude_plugins, config::playnite.autosync_remove_uninstalled, config::playnite.exclude_hidden_games, changed, matched);
+      platf::playnite::sync::autosync_reconcile(root, all, library_complete, recentN, recent_age_days, delete_after_days, config::playnite.autosync_require_replacement, config::playnite.sync_all_installed, config::playnite.sync_categories, config::playnite.sync_plugins, config::playnite.exclude_categories, config::playnite.exclude_games, config::playnite.exclude_plugins, config::playnite.autosync_remove_uninstalled, config::playnite.exclude_hidden_games, changed, matched);
       if (changed) {
         platf::playnite::sync::write_and_refresh_apps(root, config::stream.file_apps);
       }
@@ -940,6 +963,8 @@ namespace platf::playnite {
     mutable std::mutex client_mutex_;
     bool new_snapshot_ = true;  // Indicates next games message starts a new accumulation
     bool snapshot_markers_supported_ = false;  // Plugin sends snapshotStart/snapshotComplete (reset per connection)
+    bool library_complete_ = false;  // last_games_ holds a whole library, not a partial accumulation
+    bool library_confirmed_empty_ = false;  // Plugin explicitly reported a zero-game library
     uint64_t snapshot_generation_ = 0;  // Incremented on every completed snapshot
     std::condition_variable snapshot_cv_;  // Signals snapshot completion (paired with mutex_)
     std::unordered_set<std::string> game_ids_;  // Track unique IDs during accumulation

--- a/src/platform/windows/playnite_protocol.cpp
+++ b/src/platform/windows/playnite_protocol.cpp
@@ -97,6 +97,7 @@ namespace platf::playnite {
           game.last_played = g.value("lastPlayed", "");
           game.box_art_path = g.value("boxArtPath", "");
           game.icon_path = g.value("iconPath", "");
+          game.background_path = g.value("backgroundPath", "");
           game.description = g.value("description", "");
           game.tags = to_string_list(g.value("tags", json::array()));
           // Metadata passthrough (Playnite-enriched). Lists default to empty, scores to -1.

--- a/src/platform/windows/playnite_protocol.cpp
+++ b/src/platform/windows/playnite_protocol.cpp
@@ -130,6 +130,9 @@ namespace platf::playnite {
             inst = true;
           }
           game.installed = inst;
+          // Hidden flag may be provided as 'hidden' or 'isHidden'; older plugins send neither,
+          // in which case no game is treated as hidden.
+          game.hidden = g.value("hidden", false) || g.value("isHidden", false);
           if (!game.id.empty()) {
             m.games.emplace_back(std::move(game));
           }

--- a/src/platform/windows/playnite_protocol.cpp
+++ b/src/platform/windows/playnite_protocol.cpp
@@ -99,6 +99,21 @@ namespace platf::playnite {
           game.icon_path = g.value("iconPath", "");
           game.description = g.value("description", "");
           game.tags = to_string_list(g.value("tags", json::array()));
+          // Metadata passthrough (Playnite-enriched). Lists default to empty, scores to -1.
+          game.genres = to_string_list(g.value("genres", json::array()));
+          game.developers = to_string_list(g.value("developers", json::array()));
+          game.publishers = to_string_list(g.value("publishers", json::array()));
+          game.release_date = g.value("releaseDate", "");
+          try {
+            if (g.contains("communityScore") && g["communityScore"].is_number()) {
+              game.community_score = g["communityScore"].get<int>();
+            }
+          } catch (...) {}
+          try {
+            if (g.contains("criticScore") && g["criticScore"].is_number()) {
+              game.critic_score = g["criticScore"].get<int>();
+            }
+          } catch (...) {}
           // Installed flag may be provided as 'installed' or 'isInstalled'.
           // If neither field is present, assume installed=true to avoid filtering out everything.
           bool has1 = g.contains("installed");

--- a/src/platform/windows/playnite_protocol.cpp
+++ b/src/platform/windows/playnite_protocol.cpp
@@ -141,6 +141,8 @@ namespace platf::playnite {
         m.type = MessageType::SnapshotStart;
       } else if (type == "snapshotComplete") {
         m.type = MessageType::SnapshotComplete;
+        // Older plugins omit the count; -1 keeps "unknown" distinct from a genuinely empty library.
+        m.snapshot_games_count = j.value("games", -1);
       } else if (type == "status") {
         m.type = MessageType::Status;
         const auto &st = j.value("status", json::object());

--- a/src/platform/windows/playnite_protocol.h
+++ b/src/platform/windows/playnite_protocol.h
@@ -61,6 +61,14 @@ namespace platf::playnite {
     std::string description;  ///< Optional description / notes.
     std::vector<std::string> tags;  ///< Tag list.
     bool installed = false;  ///< Installation state (installed / isInstalled).
+    // Metadata Playnite already enriched (e.g. via its IGDB add-on). Passed straight through
+    // so the client can display it; empty/-1 mean the game has no such value.
+    std::vector<std::string> genres;  ///< Genre names (genres).
+    std::vector<std::string> developers;  ///< Developer company names (developers).
+    std::vector<std::string> publishers;  ///< Publisher company names (publishers).
+    std::string release_date;  ///< Release date as Playnite formats it (releaseDate).
+    int community_score = -1;  ///< Community score 0-100, or -1 when absent (communityScore).
+    int critic_score = -1;  ///< Critic score 0-100, or -1 when absent (criticScore).
   };
 
   /**

--- a/src/platform/windows/playnite_protocol.h
+++ b/src/platform/windows/playnite_protocol.h
@@ -64,6 +64,7 @@ namespace platf::playnite {
     std::string description;  ///< Optional description / notes.
     std::vector<std::string> tags;  ///< Tag list.
     bool installed = false;  ///< Installation state (installed / isInstalled).
+    bool hidden = false;  ///< Hidden in the Playnite library (hidden / isHidden).
     // Metadata Playnite already enriched (e.g. via its IGDB add-on). Passed straight through
     // so the client can display it; empty/-1 mean the game has no such value.
     std::vector<std::string> genres;  ///< Genre names (genres).

--- a/src/platform/windows/playnite_protocol.h
+++ b/src/platform/windows/playnite_protocol.h
@@ -58,6 +58,7 @@ namespace platf::playnite {
     std::string last_played;  ///< Last played timestamp (ISO8601) (lastPlayed).
     std::string box_art_path;  ///< Path/URL to cover art (boxArtPath).
     std::string icon_path;  ///< Path/URL to game icon (iconPath).
+    std::string background_path;  ///< Path/URL to background/hero art (backgroundPath).
     std::string description;  ///< Optional description / notes.
     std::vector<std::string> tags;  ///< Tag list.
     bool installed = false;  ///< Installation state (installed / isInstalled).

--- a/src/platform/windows/playnite_protocol.h
+++ b/src/platform/windows/playnite_protocol.h
@@ -83,6 +83,7 @@ namespace platf::playnite {
     std::vector<Category> categories;  ///< Categories payload (if type == Categories).
     std::vector<Plugin> plugins;  ///< Plugins payload (if type == Plugins).
     std::vector<Game> games;  ///< Games payload (if type == Games).
+    int snapshot_games_count = -1;  ///< Games the plugin says it sent (if type == SnapshotComplete); -1 when not reported.
     // Status payload (if type == Status)
     std::string status_name;  ///< Status event name (e.g. gameStarted, gameStopped).
     std::string status_game_id;  ///< Associated game id.

--- a/src/platform/windows/playnite_sync.cpp
+++ b/src/platform/windows/playnite_sync.cpp
@@ -546,6 +546,38 @@ namespace platf::playnite::sync {
         app.erase("playnite-plugin-name");
       }
     } catch (...) {}
+    // Metadata passthrough: mirror Playnite-enriched fields into the app node so they can be
+    // served to clients. Absent values are erased to keep apps.json tidy and idempotent.
+    try {
+      auto set_or_erase_str = [&](const char *key, const std::string &val) {
+        if (!val.empty()) {
+          app[key] = val;
+        } else if (app.contains(key)) {
+          app.erase(key);
+        }
+      };
+      auto set_or_erase_list = [&](const char *key, const std::vector<std::string> &vals) {
+        if (!vals.empty()) {
+          app[key] = vals;
+        } else if (app.contains(key)) {
+          app.erase(key);
+        }
+      };
+      auto set_or_erase_score = [&](const char *key, int score) {
+        if (score >= 0) {
+          app[key] = score;
+        } else if (app.contains(key)) {
+          app.erase(key);
+        }
+      };
+      set_or_erase_str("playnite-description", g.description);
+      set_or_erase_list("playnite-genres", g.genres);
+      set_or_erase_list("playnite-developers", g.developers);
+      set_or_erase_list("playnite-publishers", g.publishers);
+      set_or_erase_str("playnite-release-date", g.release_date);
+      set_or_erase_score("playnite-community-score", g.community_score);
+      set_or_erase_score("playnite-critic-score", g.critic_score);
+    } catch (...) {}
   }
 
   void mark_app_as_playnite_auto(nlohmann::json &app, int flags) {

--- a/src/platform/windows/playnite_sync.cpp
+++ b/src/platform/windows/playnite_sync.cpp
@@ -496,6 +496,19 @@ namespace platf::playnite::sync {
       }
     } catch (...) {}
     try {
+      bool stored = false;
+      if (!g.background_path.empty()) {
+        auto dst = platf::appdata() / "covers" / ("playnite_bg_" + g.id + ".png");
+        if (convert_playnite_image_to_png(g.background_path, dst)) {
+          app["playnite-background"] = dst.generic_string();
+          stored = true;
+        }
+      }
+      if (!stored && app.contains("playnite-background")) {
+        app.erase("playnite-background");
+      }
+    } catch (...) {}
+    try {
       auto dst = platf::appdata() / "covers" / ("playnite_icon_" + g.id + ".png");
       // Resolve the install dir from the plugin's explicit field, the library working dir, or the
       // dir cached from a prior "gameStarted" status message (Steam/URL games expose none in the

--- a/src/platform/windows/playnite_sync.cpp
+++ b/src/platform/windows/playnite_sync.cpp
@@ -411,6 +411,18 @@ namespace platf::playnite::sync {
                     installed.end());
   }
 
+  void snapshot_hidden(const std::vector<Game> &all, std::vector<Game> &installed, std::unordered_set<std::string> &hidden_lower) {
+    for (const auto &g : all) {
+      if (g.hidden && !g.id.empty()) {
+        hidden_lower.insert(playnite_id_key(g.id));
+      }
+    }
+    installed.erase(std::remove_if(installed.begin(), installed.end(), [](const auto &g) {
+                      return g.hidden;
+                    }),
+                    installed.end());
+  }
+
   std::unordered_map<std::string, std::time_t> build_last_played_map(const std::vector<Game> &installed) {
     std::unordered_map<std::string, std::time_t> m;
     for (const auto &g : installed) {
@@ -754,7 +766,7 @@ namespace platf::playnite::sync {
     return c;
   }
 
-  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed) {
+  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed) {
     auto cur = current_auto_ids(root);
     auto repl = count_replacements_available(cur, selected_ids);
     nlohmann::json kept = nlohmann::json::array();
@@ -770,7 +782,7 @@ namespace platf::playnite::sync {
         }
       } catch (...) {}
       if (is_auto && !pid.empty()) {
-        if ((remove_uninstalled && uninstalled_lower.contains(pid_key)) || should_ttl_delete(app, delete_after_days, now_time, last_played_map)) {
+        if ((remove_uninstalled && uninstalled_lower.contains(pid_key)) || hidden_lower.contains(pid_key) || should_ttl_delete(app, delete_after_days, now_time, last_played_map)) {
           changed = true;
           continue;
         }
@@ -804,7 +816,7 @@ namespace platf::playnite::sync {
 }  // namespace platf::playnite::sync
 
 namespace platf::playnite::sync {
-  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool &changed, std::size_t &matched_out) {
+  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out) {
     if (!root.contains("apps") || !root["apps"].is_array()) {
       root["apps"] = nlohmann::json::array();
     }
@@ -818,6 +830,12 @@ namespace platf::playnite::sync {
     std::vector<Game> installed;
     std::unordered_set<std::string> uninstalled_lower;
     snapshot_installed_and_uninstalled(all_games, installed, uninstalled_lower);
+
+    // Games hidden in Playnite are never selectable, and already-synced ones are purged below.
+    std::unordered_set<std::string> hidden_lower;
+    if (exclude_hidden) {
+      snapshot_hidden(all_games, installed, hidden_lower);
+    }
 
     // Build exclusion sets
     auto excl = build_exclusion_lower(exclude_ids);
@@ -907,7 +925,7 @@ namespace platf::playnite::sync {
       selected_ids.insert(playnite_id_key(g.id));
     }
     const bool recent_mode = (recentN > 0);
-    purge_uninstalled_and_ttl(root, uninstalled_lower, delete_after_days, std::time(nullptr), last_played_map, recent_mode, require_repl, remove_uninstalled, sync_all_installed, selected_ids, changed);
+    purge_uninstalled_and_ttl(root, uninstalled_lower, hidden_lower, delete_after_days, std::time(nullptr), last_played_map, recent_mode, require_repl, remove_uninstalled, sync_all_installed, selected_ids, changed);
 
     // Add missing
     add_missing_auto_entries(root, selected, matched_ids, source_flags, changed);

--- a/src/platform/windows/playnite_sync.cpp
+++ b/src/platform/windows/playnite_sync.cpp
@@ -618,6 +618,14 @@ namespace platf::playnite::sync {
       set_or_erase_str("playnite-release-date", g.release_date);
       set_or_erase_score("playnite-community-score", g.community_score);
       set_or_erase_score("playnite-critic-score", g.critic_score);
+      set_or_erase_str("playnite-last-played", g.last_played);
+      // Zero playtime is the same as none for a client ordering a library, so it is erased
+      // rather than written, keeping apps.json free of a key on every never-played game.
+      if (g.playtime_minutes > 0) {
+        app["playnite-playtime-minutes"] = g.playtime_minutes;
+      } else if (app.contains("playnite-playtime-minutes")) {
+        app.erase("playnite-playtime-minutes");
+      }
     } catch (...) {}
   }
 

--- a/src/platform/windows/playnite_sync.cpp
+++ b/src/platform/windows/playnite_sync.cpp
@@ -766,7 +766,7 @@ namespace platf::playnite::sync {
     return c;
   }
 
-  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed) {
+  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, const std::unordered_set<std::string> &known_ids_lower, bool library_complete, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed) {
     auto cur = current_auto_ids(root);
     auto repl = count_replacements_available(cur, selected_ids);
     nlohmann::json kept = nlohmann::json::array();
@@ -783,6 +783,13 @@ namespace platf::playnite::sync {
       } catch (...) {}
       if (is_auto && !pid.empty()) {
         if ((remove_uninstalled && uninstalled_lower.contains(pid_key)) || hidden_lower.contains(pid_key) || should_ttl_delete(app, delete_after_days, now_time, last_played_map)) {
+          changed = true;
+          continue;
+        }
+        // Deleted from the Playnite library: the game is absent from the snapshot entirely, so it
+        // shows up in neither the uninstalled nor the hidden set. Such an entry can never launch
+        // again, so drop it regardless of remove_uninstalled -- but only against a full snapshot.
+        if (library_complete && !known_ids_lower.contains(pid_key)) {
           changed = true;
           continue;
         }
@@ -816,7 +823,7 @@ namespace platf::playnite::sync {
 }  // namespace platf::playnite::sync
 
 namespace platf::playnite::sync {
-  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out) {
+  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, bool library_complete, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out) {
     if (!root.contains("apps") || !root["apps"].is_array()) {
       root["apps"] = nlohmann::json::array();
     }
@@ -830,6 +837,15 @@ namespace platf::playnite::sync {
     std::vector<Game> installed;
     std::unordered_set<std::string> uninstalled_lower;
     snapshot_installed_and_uninstalled(all_games, installed, uninstalled_lower);
+
+    // Every id Playnite still knows about, installed or not. Auto apps outside this set were
+    // removed from the library rather than merely uninstalled.
+    std::unordered_set<std::string> known_ids_lower;
+    for (const auto &g : all_games) {
+      if (!g.id.empty()) {
+        known_ids_lower.insert(playnite_id_key(g.id));
+      }
+    }
 
     // Games hidden in Playnite are never selectable, and already-synced ones are purged below.
     std::unordered_set<std::string> hidden_lower;
@@ -925,7 +941,7 @@ namespace platf::playnite::sync {
       selected_ids.insert(playnite_id_key(g.id));
     }
     const bool recent_mode = (recentN > 0);
-    purge_uninstalled_and_ttl(root, uninstalled_lower, hidden_lower, delete_after_days, std::time(nullptr), last_played_map, recent_mode, require_repl, remove_uninstalled, sync_all_installed, selected_ids, changed);
+    purge_uninstalled_and_ttl(root, uninstalled_lower, hidden_lower, known_ids_lower, library_complete, delete_after_days, std::time(nullptr), last_played_map, recent_mode, require_repl, remove_uninstalled, sync_all_installed, selected_ids, changed);
 
     // Add missing
     add_missing_auto_entries(root, selected, matched_ids, source_flags, changed);

--- a/src/platform/windows/playnite_sync.h
+++ b/src/platform/windows/playnite_sync.h
@@ -53,6 +53,8 @@ namespace platf::playnite::sync {
   // Additional small helpers for apps.json reconciliation
   std::unordered_set<std::string> build_exclusion_lower(const std::vector<std::string> &ids);
   void snapshot_installed_and_uninstalled(const std::vector<Game> &all, std::vector<Game> &installed, std::unordered_set<std::string> &uninstalled_lower);
+  // Collects ids of games hidden in Playnite and drops them from the installed candidates.
+  void snapshot_hidden(const std::vector<Game> &all, std::vector<Game> &installed, std::unordered_set<std::string> &hidden_lower);
   std::unordered_map<std::string, std::time_t> build_last_played_map(const std::vector<Game> &installed);
   const Game *match_app_against_indexes(const nlohmann::json &app, const std::unordered_map<std::string, GameRef> &by_id, const std::unordered_map<std::string, GameRef> &by_exe, const std::unordered_map<std::string, GameRef> &by_dir, const std::unordered_map<std::string, GameRef> &by_unique_name);
   // Art conversion cache: identity of the source image (path+size+mtime) that produced a converted PNG.
@@ -68,10 +70,10 @@ namespace platf::playnite::sync {
   // Purge helpers
   std::unordered_set<std::string> current_auto_ids(const nlohmann::json &root);
   std::size_t count_replacements_available(const std::unordered_set<std::string> &current_auto, const std::unordered_set<std::string> &selected_ids);
-  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed);
+  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed);
 
   // Orchestration helper: performs full autosync reconciliation into root["apps"].
   // Combines recent and category selections, merges source flags, purges, and adds missing entries.
-  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool &changed, std::size_t &matched_out);
+  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out);
 
 }  // namespace platf::playnite::sync

--- a/src/platform/windows/playnite_sync.h
+++ b/src/platform/windows/playnite_sync.h
@@ -70,10 +70,15 @@ namespace platf::playnite::sync {
   // Purge helpers
   std::unordered_set<std::string> current_auto_ids(const nlohmann::json &root);
   std::size_t count_replacements_available(const std::unordered_set<std::string> &current_auto, const std::unordered_set<std::string> &selected_ids);
-  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed);
+  // known_ids_lower holds every id in the Playnite snapshot; auto apps whose id is absent were
+  // deleted from the library and are purged, but only when library_complete says the snapshot is
+  // the whole library rather than a partially accumulated one.
+  void purge_uninstalled_and_ttl(nlohmann::json &root, const std::unordered_set<std::string> &uninstalled_lower, const std::unordered_set<std::string> &hidden_lower, const std::unordered_set<std::string> &known_ids_lower, bool library_complete, int delete_after_days, std::time_t now_time, const std::unordered_map<std::string, std::time_t> &last_played_map, bool recent_mode, bool require_repl, bool remove_uninstalled, bool sync_all_installed, const std::unordered_set<std::string> &selected_ids, bool &changed);
 
   // Orchestration helper: performs full autosync reconciliation into root["apps"].
   // Combines recent and category selections, merges source flags, purges, and adds missing entries.
-  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out);
+  // library_complete tells whether all_games is a full library snapshot; when false, auto apps
+  // missing from it are kept because the rest of the library may simply not have arrived yet.
+  void autosync_reconcile(nlohmann::json &root, const std::vector<Game> &all_games, bool library_complete, int recentN, int recentAgeDays, int delete_after_days, bool require_repl, bool sync_all_installed, const std::vector<std::string> &categories, const std::vector<std::string> &include_plugins, const std::vector<std::string> &exclude_categories, const std::vector<std::string> &exclude_ids, const std::vector<std::string> &exclude_plugins, bool remove_uninstalled, bool exclude_hidden, bool &changed, std::size_t &matched_out);
 
 }  // namespace platf::playnite::sync

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3689,10 +3689,11 @@ namespace proc {
           meta.release_date = read_string("playnite-release-date");
           meta.community_score = read_score("playnite-community-score");
           meta.critic_score = read_score("playnite-critic-score");
+          meta.background_image_path = parse_env_val(this_env, read_string("playnite-background"));
           meta.present = !meta.description.empty() || !meta.genres.empty() ||
                          !meta.developers.empty() || !meta.publishers.empty() ||
                          !meta.release_date.empty() || meta.community_score >= 0 ||
-                         meta.critic_score >= 0;
+                         meta.critic_score >= 0 || !meta.background_image_path.empty();
         }
         ctx.playnite_fullscreen = false;
         if (app_node.contains("playnite-fullscreen")) {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3653,6 +3653,47 @@ namespace proc {
             ctx.playnite_id.clear();
           }
         }
+
+        // Playnite-enriched metadata passthrough (written by the Playnite sync). Only the
+        // fields present are populated; `present` records whether the app carries any at all.
+        {
+          auto &meta = ctx.playnite_metadata;
+          meta = proc::playnite_metadata_t {};
+          auto read_string = [&](const char *key) -> std::string {
+            if (auto it = app_node.find(key); it != app_node.end() && it->is_string()) {
+              return it->get<std::string>();
+            }
+            return {};
+          };
+          auto read_list = [&](const char *key) -> std::vector<std::string> {
+            std::vector<std::string> out;
+            if (auto it = app_node.find(key); it != app_node.end() && it->is_array()) {
+              for (const auto &v : *it) {
+                if (v.is_string()) {
+                  out.push_back(v.get<std::string>());
+                }
+              }
+            }
+            return out;
+          };
+          auto read_score = [&](const char *key) -> int {
+            if (auto it = app_node.find(key); it != app_node.end() && it->is_number()) {
+              return it->get<int>();
+            }
+            return -1;
+          };
+          meta.description = read_string("playnite-description");
+          meta.genres = read_list("playnite-genres");
+          meta.developers = read_list("playnite-developers");
+          meta.publishers = read_list("playnite-publishers");
+          meta.release_date = read_string("playnite-release-date");
+          meta.community_score = read_score("playnite-community-score");
+          meta.critic_score = read_score("playnite-critic-score");
+          meta.present = !meta.description.empty() || !meta.genres.empty() ||
+                         !meta.developers.empty() || !meta.publishers.empty() ||
+                         !meta.release_date.empty() || meta.community_score >= 0 ||
+                         meta.critic_score >= 0;
+        }
         ctx.playnite_fullscreen = false;
         if (app_node.contains("playnite-fullscreen")) {
           try {

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3711,14 +3711,23 @@ namespace proc {
           meta.genres = read_list("playnite-genres");
           meta.developers = read_list("playnite-developers");
           meta.publishers = read_list("playnite-publishers");
+          auto read_uint = [&](const char *key) -> uint64_t {
+            if (auto it = app_node.find(key); it != app_node.end() && it->is_number_unsigned()) {
+              return it->get<uint64_t>();
+            }
+            return 0;
+          };
           meta.release_date = read_string("playnite-release-date");
           meta.community_score = read_score("playnite-community-score");
           meta.critic_score = read_score("playnite-critic-score");
+          meta.last_played = read_string("playnite-last-played");
+          meta.playtime_minutes = read_uint("playnite-playtime-minutes");
           meta.background_image_path = parse_env_val(this_env, read_string("playnite-background"));
           meta.present = !meta.description.empty() || !meta.genres.empty() ||
                          !meta.developers.empty() || !meta.publishers.empty() ||
                          !meta.release_date.empty() || meta.community_score >= 0 ||
-                         meta.critic_score >= 0 || !meta.background_image_path.empty();
+                         meta.critic_score >= 0 || !meta.last_played.empty() ||
+                         meta.playtime_minutes > 0 || !meta.background_image_path.empty();
         }
         ctx.playnite_fullscreen = false;
         if (app_node.contains("playnite-fullscreen")) {

--- a/src/process.h
+++ b/src/process.h
@@ -102,6 +102,19 @@ namespace proc {
     std::optional<bool> anime4k_vrs;
   };
 
+  // Playnite-enriched game metadata, carried through to clients. Absent values stay empty or
+  // -1; `present` is set when the app carries any metadata at all.
+  struct playnite_metadata_t {
+    bool present {false};
+    std::string description;
+    std::vector<std::string> genres;
+    std::vector<std::string> developers;
+    std::vector<std::string> publishers;
+    std::string release_date;
+    int community_score {-1};
+    int critic_score {-1};
+  };
+
   struct ctx_t {
     std::vector<cmd_t> prep_cmds;
     std::vector<cmd_t> state_cmds;
@@ -134,6 +147,8 @@ namespace proc {
     std::vector<std::string> id_aliases;
     // When present, this app should be launched via Playnite instead of direct cmd.
     std::string playnite_id;
+    // Playnite-enriched metadata for this app (empty/absent for non-Playnite apps).
+    playnite_metadata_t playnite_metadata;
     // When true, launch Playnite in fullscreen mode via the helper.
     bool playnite_fullscreen;
     bool frame_gen_limiter_fix;

--- a/src/process.h
+++ b/src/process.h
@@ -113,6 +113,9 @@ namespace proc {
     std::string release_date;
     int community_score {-1};
     int critic_score {-1};
+    // Local path to the converted background/hero image, served via /appbackground. Empty when
+    // the game has none.
+    std::string background_image_path;
   };
 
   struct ctx_t {

--- a/src/process.h
+++ b/src/process.h
@@ -113,6 +113,11 @@ namespace proc {
     std::string release_date;
     int community_score {-1};
     int critic_score {-1};
+    // When Playnite last recorded the game as played (ISO8601), and for how long in total.
+    // Unlike anything a client can track on its own, these cover sessions played at the PC
+    // itself. Empty / 0 when the game has never been played or Playnite reports nothing.
+    std::string last_played;
+    uint64_t playtime_minutes {0};
     // Local path to the converted background/hero image, served via /appbackground. Empty when
     // the game has none.
     std::string background_image_path;

--- a/src_assets/common/assets/web/configs/tabs/Playnite.vue
+++ b/src_assets/common/assets/web/configs/tabs/Playnite.vue
@@ -351,6 +351,17 @@
                   :disabled="!autoSyncEnabled"
                 />
               </div>
+              <div class="md:col-span-2">
+                <Checkbox
+                  v-model="config.playnite_exclude_hidden_games"
+                  id="playnite_exclude_hidden_games"
+                  :default="store.defaults.playnite_exclude_hidden_games"
+                  :localePrefix="'playnite'"
+                  label="playnite.exclude_hidden_games"
+                  desc="playnite.exclude_hidden_games_desc"
+                  :disabled="!autoSyncEnabled"
+                />
+              </div>
               <n-text v-if="autoSyncEnabled" depth="3" class="md:col-span-2 playnite-help">
                 {{ policySummary }}
               </n-text>
@@ -1411,6 +1422,7 @@ const policySummary = computed<string>(() => {
   const syncAll = !!config.value?.playnite_sync_all_installed;
   const includePluginCount = normalizeIdNameEntries(config.value?.playnite_sync_plugins).length;
   const removeUninstalled = config.value?.playnite_autosync_remove_uninstalled !== false;
+  const excludeHidden = config.value?.playnite_exclude_hidden_games !== false;
   const parts: string[] = [];
   parts.push(
     (t('playnite.summary_recent_limit', { n }) as any) ||
@@ -1452,6 +1464,13 @@ const policySummary = computed<string>(() => {
           'Uninstalled games are removed automatically.'
       : (t('playnite.summary_remove_uninstalled_off') as any) ||
           'Uninstalled games remain until removed manually.',
+  );
+  parts.push(
+    excludeHidden
+      ? (t('playnite.summary_exclude_hidden_on') as any) ||
+          'Games hidden in Playnite are never synced.'
+      : (t('playnite.summary_exclude_hidden_off') as any) ||
+          'Games hidden in Playnite are synced like any other game.',
   );
   const excluded = (
     (config.value?.playnite_exclude_categories || []) as Array<{
@@ -1524,6 +1543,7 @@ function resetAutoSyncSection() {
     'playnite_autosync_remove_uninstalled',
     d.playnite_autosync_remove_uninstalled,
   );
+  store.updateOption('playnite_exclude_hidden_games', d.playnite_exclude_hidden_games);
   store.updateOption('playnite_sync_categories', d.playnite_sync_categories);
   store.updateOption('playnite_sync_plugins', d.playnite_sync_plugins);
   notify('success', (t('playnite.reset_done') as any) || 'Section reset to defaults.');

--- a/src_assets/common/assets/web/public/assets/locale/en.json
+++ b/src_assets/common/assets/web/public/assets/locale/en.json
@@ -1224,6 +1224,8 @@
     "plugins_include_placeholder": "Include games from these plugins",
     "remove_uninstalled": "Remove uninstalled games automatically",
     "remove_uninstalled_desc": "When enabled, Vibepollo removes auto-synced games as soon as they are uninstalled in Playnite.",
+    "exclude_hidden_games": "Skip games hidden in Playnite",
+    "exclude_hidden_games_desc": "When enabled, games flagged as hidden in Playnite are never auto-synced, and auto-synced games are removed once you hide them.",
     "extensions_dir": "Extensions directory",
     "install_dir": "Installation path override",
     "save_success": "Settings saved.",
@@ -1273,6 +1275,8 @@
     "summary_plugin_include": "Includes all games from {count} selected library plugins.",
     "summary_remove_uninstalled_on": "Uninstalled games are removed automatically.",
     "summary_remove_uninstalled_off": "Uninstalled games remain until you remove them manually.",
+    "summary_exclude_hidden_on": "Games hidden in Playnite are never synced.",
+    "summary_exclude_hidden_off": "Games hidden in Playnite are synced like any other game.",
     "summary_delete_after": "Also remove games never launched after {days} days.",
     "summary_excluded_categories": "Excluded categories: {categories}.",
     "summary_excluded_categories_more": "Excluded categories: {categories} (+{count} more)."

--- a/src_assets/common/assets/web/services/changelog.ts
+++ b/src_assets/common/assets/web/services/changelog.ts
@@ -18,7 +18,7 @@ export interface LoadChangelogResult {
 }
 
 const CHANGELOG_ASSET_URL = './assets/changelog.json';
-const GITHUB_RELEASES_URL = 'https://api.github.com/repos/Nonary/Vibepollo/releases';
+const GITHUB_RELEASES_URL = 'https://api.github.com/repos/DanieleS/Vibepollo/releases';
 
 function isChangelogEntry(value: unknown): value is ChangelogEntry {
   return !!value && typeof value === 'object' && typeof (value as ChangelogEntry).tag === 'string';

--- a/src_assets/common/assets/web/stores/config.ts
+++ b/src_assets/common/assets/web/stores/config.ts
@@ -213,6 +213,7 @@ const defaultGroups = [
       playnite_autosync_delete_after_days: 0,
       playnite_autosync_require_replacement: true,
       playnite_autosync_remove_uninstalled: true,
+      playnite_exclude_hidden_games: true,
       playnite_focus_attempts: 3,
       playnite_focus_timeout_secs: 15,
       playnite_focus_exit_on_first: false,
@@ -582,6 +583,7 @@ export const useConfigStore = defineStore('config', () => {
       'playnite_sync_all_installed',
       'playnite_autosync_require_replacement',
       'playnite_autosync_remove_uninstalled',
+      'playnite_exclude_hidden_games',
       'playnite_focus_exit_on_first',
       'playnite_fullscreen_entry_enabled',
     ];

--- a/src_assets/common/assets/web/views/DashboardView.vue
+++ b/src_assets/common/assets/web/views/DashboardView.vue
@@ -722,7 +722,7 @@ async function runVersionChecks() {
     // Remote release checks (GitHub)
     try {
       githubRelease.value = await fetch(
-        'https://api.github.com/repos/Nonary/Vibepollo/releases/latest',
+        'https://api.github.com/repos/DanieleS/Vibepollo/releases/latest',
       ).then((r) => r.json());
     } catch (e) {
       // eslint-disable-next-line no-console
@@ -730,7 +730,7 @@ async function runVersionChecks() {
     }
     // Fetch list of releases to locate prereleases and determine installed stability
     try {
-      const releases = await fetch('https://api.github.com/repos/Nonary/Vibepollo/releases').then(
+      const releases = await fetch('https://api.github.com/repos/DanieleS/Vibepollo/releases').then(
         (r) => r.json(),
       );
       if (Array.isArray(releases)) {

--- a/tests/test_config_playnite.cpp
+++ b/tests/test_config_playnite.cpp
@@ -26,13 +26,15 @@ TEST_F(PlayniteConfigFixture, Booleans_ParseCaseInsensitiveTruths) {
     {"playnite_auto_sync", "on"},
     {"playnite_autosync_require_replacement", "0"},
     {"playnite_sync_all_installed", "YES"},
-    {"playnite_autosync_remove_uninstalled", "off"}
+    {"playnite_autosync_remove_uninstalled", "off"},
+    {"playnite_exclude_hidden_games", "false"}
   };
   config::apply_playnite(vars);
   EXPECT_TRUE(config::playnite.auto_sync);
   EXPECT_FALSE(config::playnite.autosync_require_replacement);
   EXPECT_TRUE(config::playnite.sync_all_installed);
   EXPECT_FALSE(config::playnite.autosync_remove_uninstalled);
+  EXPECT_FALSE(config::playnite.exclude_hidden_games);
   EXPECT_TRUE(vars.empty());
 }
 

--- a/tests/test_playnite_autosync_reconcile.cpp
+++ b/tests/test_playnite_autosync_reconcile.cpp
@@ -36,6 +36,7 @@ TEST(PlayniteAutosync_Reconcile, AddsSelectedGamesToEmptyApps) {
                      /*exclude_ids*/ std::vector<std::string> {},
                      /*exclude_plugins*/ std::vector<std::string> {},
                      /*remove_uninstalled*/ true,
+                     /*exclude_hidden*/ true,
                      changed,
                      matched);
   EXPECT_TRUE(changed);
@@ -50,7 +51,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludeIds) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {"a"}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {"a"}, {}, true, true, changed, matched);
   EXPECT_FALSE(changed);
   EXPECT_EQ(root["apps"].size(), 0u);
 }
@@ -76,6 +77,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludeCategories) {
                      /*exclude_ids*/ {},
                      /*exclude_plugins*/ std::vector<std::string> {},
                      /*remove_uninstalled*/ true,
+                     /*exclude_hidden*/ true,
                      changed,
                      matched);
   EXPECT_TRUE(changed);
@@ -104,6 +106,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludePlugins) {
                      /*exclude_ids*/ {},
                      /*exclude_plugins*/ std::vector<std::string> {"cb91dfc9-b977-43bf-8e70-55f46e410fab"},
                      /*remove_uninstalled*/ true,
+                     /*exclude_hidden*/ true,
                      changed,
                      matched);
   EXPECT_TRUE(changed);
@@ -122,7 +125,7 @@ TEST(PlayniteAutosync_Reconcile, UpdatesExistingAndSetsManagedFields) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -141,7 +144,7 @@ TEST(PlayniteAutosync_Reconcile, MatchesExistingEntriesCaseInsensitively) {
   std::vector<Game> all {G("abc-def", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
 
   EXPECT_TRUE(changed);
   EXPECT_EQ(matched, 1u);
@@ -167,7 +170,7 @@ TEST(PlayniteAutosync_Reconcile, RemovesDuplicateAutoEntriesByPlayniteId) {
   std::vector<Game> all {G("abc-def", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
 
   EXPECT_TRUE(changed);
   EXPECT_EQ(matched, 1u);
@@ -185,7 +188,7 @@ TEST(PlayniteAutosync_Reconcile, SyncPluginsIncludesGames) {
   };
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, std::vector<std::string> {"plugin-one"}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, std::vector<std::string> {"plugin-one"}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -198,7 +201,7 @@ TEST(PlayniteAutosync_Reconcile, SyncAllInstalledIncludesAllGames) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true), G("B", "2025-01-02T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, true, {}, {}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 0, 0, 0, true, true, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 2u);
   std::unordered_set<std::string> ids;
@@ -220,7 +223,7 @@ TEST(PlayniteAutosync_Reconcile, AutoRemoveUninstalledHonorsFlag) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", false)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, true, changed, matched);
+  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root["apps"].size(), 0u);
 
@@ -229,8 +232,55 @@ TEST(PlayniteAutosync_Reconcile, AutoRemoveUninstalledHonorsFlag) {
   root["apps"].push_back(entry);
   changed = false;
   matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, false, changed, matched);
+  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, false, true, changed, matched);
   EXPECT_FALSE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
+}
+
+TEST(PlayniteAutosync_Reconcile, SkipsHiddenGamesWhenExcludeHiddenEnabled) {
+  nlohmann::json root;
+  root["apps"] = nlohmann::json::array();
+  auto hidden = G("B", "2025-01-02T00:00:00Z");
+  hidden.hidden = true;
+  std::vector<Game> all {G("A", "2025-01-01T00:00:00Z"), hidden};
+  bool changed = false;
+  std::size_t matched = 0;
+  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ true, changed, matched);
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(root["apps"].size(), 1u);
+  EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
+}
+
+TEST(PlayniteAutosync_Reconcile, SyncsHiddenGamesWhenExcludeHiddenDisabled) {
+  nlohmann::json root;
+  root["apps"] = nlohmann::json::array();
+  auto hidden = G("B", "2025-01-02T00:00:00Z");
+  hidden.hidden = true;
+  std::vector<Game> all {hidden};
+  bool changed = false;
+  std::size_t matched = 0;
+  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ false, changed, matched);
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(root["apps"].size(), 1u);
+  EXPECT_EQ(root["apps"][0]["playnite-id"], "B");
+}
+
+TEST(PlayniteAutosync_Reconcile, RemovesAutoEntryWhenGameBecomesHidden) {
+  nlohmann::json root;
+  root["apps"] = nlohmann::json::array();
+  nlohmann::json entry;
+  entry["playnite-id"] = "A";
+  entry["playnite-managed"] = "auto";
+  entry["playnite-source"] = "installed";
+  root["apps"].push_back(entry);
+  auto hidden = G("A", "2025-01-01T00:00:00Z");
+  hidden.hidden = true;
+  std::vector<Game> all {hidden};
+  bool changed = false;
+  std::size_t matched = 0;
+  // Removal happens even with remove_uninstalled disabled: the game is installed, just hidden.
+  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, false, /*exclude_hidden*/ true, changed, matched);
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(root["apps"].size(), 0u);
 }

--- a/tests/test_playnite_autosync_reconcile.cpp
+++ b/tests/test_playnite_autosync_reconcile.cpp
@@ -24,8 +24,7 @@ TEST(PlayniteAutosync_Reconcile, AddsSelectedGamesToEmptyApps) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true), G("B", "2024-01-01T00:00:00Z", true, {"RPG"})};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all,
-                     /*recentN*/ 1,
+  autosync_reconcile(root, all, true /*library complete*/, /*recentN*/ 1,
                      /*recentAgeDays*/ 0,
                      /*delete_after_days*/ 0,
                      /*require_repl*/ true,
@@ -51,7 +50,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludeIds) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {"a"}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 1, 0, 0, true, false, {}, {}, {}, {"a"}, {}, true, true, changed, matched);
   EXPECT_FALSE(changed);
   EXPECT_EQ(root["apps"].size(), 0u);
 }
@@ -65,8 +64,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludeCategories) {
   };
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all,
-                     /*recentN*/ 2,
+  autosync_reconcile(root, all, true /*library complete*/, /*recentN*/ 2,
                      /*recentAgeDays*/ 0,
                      /*delete_after_days*/ 0,
                      /*require_repl*/ true,
@@ -94,8 +92,7 @@ TEST(PlayniteAutosync_Reconcile, HonorsExcludePlugins) {
   };
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all,
-                     /*recentN*/ 2,
+  autosync_reconcile(root, all, true /*library complete*/, /*recentN*/ 2,
                      /*recentAgeDays*/ 0,
                      /*delete_after_days*/ 0,
                      /*require_repl*/ true,
@@ -125,7 +122,7 @@ TEST(PlayniteAutosync_Reconcile, UpdatesExistingAndSetsManagedFields) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -144,7 +141,7 @@ TEST(PlayniteAutosync_Reconcile, MatchesExistingEntriesCaseInsensitively) {
   std::vector<Game> all {G("abc-def", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
 
   EXPECT_TRUE(changed);
   EXPECT_EQ(matched, 1u);
@@ -170,7 +167,7 @@ TEST(PlayniteAutosync_Reconcile, RemovesDuplicateAutoEntriesByPlayniteId) {
   std::vector<Game> all {G("abc-def", "2025-01-01T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 1, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
 
   EXPECT_TRUE(changed);
   EXPECT_EQ(matched, 1u);
@@ -188,7 +185,7 @@ TEST(PlayniteAutosync_Reconcile, SyncPluginsIncludesGames) {
   };
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, std::vector<std::string> {"plugin-one"}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, false, {}, std::vector<std::string> {"plugin-one"}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -201,7 +198,7 @@ TEST(PlayniteAutosync_Reconcile, SyncAllInstalledIncludesAllGames) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", true), G("B", "2025-01-02T00:00:00Z", true)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, true, {}, {}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, true, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 2u);
   std::unordered_set<std::string> ids;
@@ -223,7 +220,7 @@ TEST(PlayniteAutosync_Reconcile, AutoRemoveUninstalledHonorsFlag) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z", false)};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, false, {}, {}, {}, {}, {}, true, true, changed, matched);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root["apps"].size(), 0u);
 
@@ -232,10 +229,51 @@ TEST(PlayniteAutosync_Reconcile, AutoRemoveUninstalledHonorsFlag) {
   root["apps"].push_back(entry);
   changed = false;
   matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, false, {}, {}, {}, {}, {}, false, true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, false, {}, {}, {}, {}, {}, false, true, changed, matched);
   EXPECT_FALSE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
+}
+
+TEST(PlayniteAutosync_Reconcile, RemovesAutoEntryDeletedFromLibrary) {
+  nlohmann::json root;
+  root["apps"] = nlohmann::json::array();
+  for (auto id : {"A", "B"}) {
+    nlohmann::json entry;
+    entry["playnite-id"] = id;
+    entry["playnite-managed"] = "auto";
+    entry["playnite-source"] = "installed";
+    root["apps"].push_back(entry);
+  }
+  // B was deleted from Playnite, so it is absent from the snapshot rather than flagged uninstalled.
+  std::vector<Game> all {G("A", "2025-01-01T00:00:00Z")};
+  bool changed = false;
+  std::size_t matched = 0;
+  // Removal happens even with remove_uninstalled disabled: the game no longer exists to launch.
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, false, true, changed, matched);
+  EXPECT_TRUE(changed);
+  ASSERT_EQ(root["apps"].size(), 1u);
+  EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
+}
+
+TEST(PlayniteAutosync_Reconcile, KeepsAutoEntryMissingFromPartialSnapshot) {
+  nlohmann::json root;
+  root["apps"] = nlohmann::json::array();
+  nlohmann::json entry;
+  entry["playnite-id"] = "B";
+  entry["playnite-managed"] = "auto";
+  entry["playnite-source"] = "installed";
+  root["apps"].push_back(entry);
+  // B is missing only because the snapshot is still accumulating; purging it would be wrong.
+  std::vector<Game> all {G("A", "2025-01-01T00:00:00Z")};
+  bool changed = false;
+  std::size_t matched = 0;
+  autosync_reconcile(root, all, false /*library complete*/, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, false, true, changed, matched);
+  std::unordered_set<std::string> ids;
+  for (auto &app : root["apps"]) {
+    ids.insert(app["playnite-id"].get<std::string>());
+  }
+  EXPECT_TRUE(ids.contains("B"));
 }
 
 TEST(PlayniteAutosync_Reconcile, SkipsHiddenGamesWhenExcludeHiddenEnabled) {
@@ -246,7 +284,7 @@ TEST(PlayniteAutosync_Reconcile, SkipsHiddenGamesWhenExcludeHiddenEnabled) {
   std::vector<Game> all {G("A", "2025-01-01T00:00:00Z"), hidden};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ true, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -260,7 +298,7 @@ TEST(PlayniteAutosync_Reconcile, SyncsHiddenGamesWhenExcludeHiddenDisabled) {
   std::vector<Game> all {hidden};
   bool changed = false;
   std::size_t matched = 0;
-  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ false, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, true, /*exclude_hidden*/ false, changed, matched);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "B");
@@ -280,7 +318,7 @@ TEST(PlayniteAutosync_Reconcile, RemovesAutoEntryWhenGameBecomesHidden) {
   bool changed = false;
   std::size_t matched = 0;
   // Removal happens even with remove_uninstalled disabled: the game is installed, just hidden.
-  autosync_reconcile(root, all, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, false, /*exclude_hidden*/ true, changed, matched);
+  autosync_reconcile(root, all, true /*library complete*/, 0, 0, 0, true, /*sync_all_installed*/ true, {}, {}, {}, {}, {}, false, /*exclude_hidden*/ true, changed, matched);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root["apps"].size(), 0u);
 }

--- a/tests/test_playnite_protocol.cpp
+++ b/tests/test_playnite_protocol.cpp
@@ -112,6 +112,24 @@ TEST(PlayniteProtocol_Parse, Games_InstalledField_PrecedenceAndDefault) {
   EXPECT_TRUE(m.games[3].installed);  // default true when neither present
 }
 
+TEST(PlayniteProtocol_Parse, Games_HiddenField_AliasesAndDefault) {
+  std::string j = R"({
+    "type":"games",
+    "payload":[
+      {"id":"a","hidden":true},
+      {"id":"b","isHidden":true},
+      {"id":"c","hidden":false},
+      {"id":"d"}
+    ]})";
+  auto m = platf::playnite::parse(bytes(j));
+  ASSERT_EQ(m.type, MessageType::Games);
+  ASSERT_EQ(m.games.size(), 4u);
+  EXPECT_TRUE(m.games[0].hidden);
+  EXPECT_TRUE(m.games[1].hidden);
+  EXPECT_FALSE(m.games[2].hidden);
+  EXPECT_FALSE(m.games[3].hidden);  // default false when absent (older plugin)
+}
+
 TEST(PlayniteProtocol_Parse, Games_SkipsMissingId) {
   std::string j = R"({"type":"games","payload":[{"name":"no-id"}]})";
   auto m = platf::playnite::parse(bytes(j));

--- a/tests/test_playnite_protocol.cpp
+++ b/tests/test_playnite_protocol.cpp
@@ -26,6 +26,20 @@ TEST(PlayniteProtocol_Parse, UnknownType_ReturnsUnknown) {
   EXPECT_EQ(m.type, MessageType::Unknown);
 }
 
+TEST(PlayniteProtocol_Parse, SnapshotComplete_ParsesGamesCount) {
+  auto m = platf::playnite::parse(bytes("{\"type\":\"snapshotComplete\",\"games\":42}"));
+  EXPECT_EQ(m.type, MessageType::SnapshotComplete);
+  EXPECT_EQ(m.snapshot_games_count, 42);
+
+  // An explicit zero is what distinguishes an emptied library from lost batches.
+  m = platf::playnite::parse(bytes("{\"type\":\"snapshotComplete\",\"games\":0}"));
+  EXPECT_EQ(m.snapshot_games_count, 0);
+
+  // Older plugins omit the field entirely.
+  m = platf::playnite::parse(bytes("{\"type\":\"snapshotComplete\"}"));
+  EXPECT_EQ(m.snapshot_games_count, -1);
+}
+
 TEST(PlayniteProtocol_Parse, Categories_ParsesAndSkipsEmpty) {
   std::string j = R"({
     "type":"categories",

--- a/tests/test_playnite_sync.cpp
+++ b/tests/test_playnite_sync.cpp
@@ -99,11 +99,13 @@ TEST(PlayniteSync_Purge, TTLAndReplacementPolicy) {
   app["playnite-added-at"] = "2000-01-01T00:00:00Z";
   root["apps"].push_back(app);
   std::unordered_set<std::string> uninstalled;  // not uninstalled
+  std::unordered_set<std::string> no_hidden;
+  std::unordered_set<std::string> known {"x"};  // still in the library
   auto now = std::time(nullptr);
   std::unordered_map<std::string, std::time_t> last_played;  // empty => never played
   std::unordered_set<std::string> selected_ids;  // not selected
   bool changed = false;
-  purge_uninstalled_and_ttl(root, uninstalled, 1 /*days*/, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, false /*sync all*/, selected_ids, changed);
+  purge_uninstalled_and_ttl(root, uninstalled, no_hidden, known, true /*library complete*/, 1 /*days*/, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, false /*sync all*/, selected_ids, changed);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root["apps"].size(), 0);
 }

--- a/tests/test_playnite_sync_autosync.cpp
+++ b/tests/test_playnite_sync_autosync.cpp
@@ -112,12 +112,13 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
     root["apps"].push_back(a);
   }
   std::unordered_set<std::string> uninstalled_lower {to_lower_copy(std::string("B"))};
+  std::unordered_set<std::string> no_hidden;
   auto now = std::time(nullptr);
   std::unordered_map<std::string, std::time_t> last_played;
   // selected set contains only A, so B is candidate for purge by uninstall and A remains
   std::unordered_set<std::string> selected_ids {"A"};
   bool changed = false;
-  purge_uninstalled_and_ttl(root, uninstalled_lower, 0, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, true /*sync all*/, selected_ids, changed);
+  purge_uninstalled_and_ttl(root, uninstalled_lower, no_hidden, 0, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, true /*sync all*/, selected_ids, changed);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -133,7 +134,7 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
   std::unordered_set<std::string> none;
   std::unordered_set<std::string> selected {"Y"};  // Y not present currently, so 1 replacement available
   changed = false;
-  purge_uninstalled_and_ttl(root2, none, 0, now, last_played, true, true, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
+  purge_uninstalled_and_ttl(root2, none, no_hidden, 0, now, last_played, true, true, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root2["apps"].size(), 0u);  // removed because replacement exists and require_repl=true
 
@@ -145,7 +146,7 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
   x2["playnite-managed"] = "auto";
   root3["apps"].push_back(x2);
   changed = false;
-  purge_uninstalled_and_ttl(root3, none, 0, now, last_played, true, false, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
+  purge_uninstalled_and_ttl(root3, none, no_hidden, 0, now, last_played, true, false, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
   EXPECT_FALSE(changed);
   EXPECT_EQ(root3["apps"].size(), 1u);
 }

--- a/tests/test_playnite_sync_autosync.cpp
+++ b/tests/test_playnite_sync_autosync.cpp
@@ -113,12 +113,15 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
   }
   std::unordered_set<std::string> uninstalled_lower {to_lower_copy(std::string("B"))};
   std::unordered_set<std::string> no_hidden;
+  // These cases exercise the uninstall/TTL/replacement paths, not library deletion, so the
+  // library-complete criterion is switched off and the known-id set is left empty.
+  std::unordered_set<std::string> no_known;
   auto now = std::time(nullptr);
   std::unordered_map<std::string, std::time_t> last_played;
   // selected set contains only A, so B is candidate for purge by uninstall and A remains
   std::unordered_set<std::string> selected_ids {"A"};
   bool changed = false;
-  purge_uninstalled_and_ttl(root, uninstalled_lower, no_hidden, 0, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, true /*sync all*/, selected_ids, changed);
+  purge_uninstalled_and_ttl(root, uninstalled_lower, no_hidden, no_known, false /*library complete*/, 0, now, last_played, true /*recent*/, true /*require repl*/, true /*remove uninstalled*/, true /*sync all*/, selected_ids, changed);
   EXPECT_TRUE(changed);
   ASSERT_EQ(root["apps"].size(), 1u);
   EXPECT_EQ(root["apps"][0]["playnite-id"], "A");
@@ -134,7 +137,7 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
   std::unordered_set<std::string> none;
   std::unordered_set<std::string> selected {"Y"};  // Y not present currently, so 1 replacement available
   changed = false;
-  purge_uninstalled_and_ttl(root2, none, no_hidden, 0, now, last_played, true, true, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
+  purge_uninstalled_and_ttl(root2, none, no_hidden, no_known, false /*library complete*/, 0, now, last_played, true, true, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
   EXPECT_TRUE(changed);
   EXPECT_EQ(root2["apps"].size(), 0u);  // removed because replacement exists and require_repl=true
 
@@ -146,7 +149,7 @@ TEST(PlayniteSync_Purge, RemovesUninstalledAndOptionallyNonSelectedWhenReplaceme
   x2["playnite-managed"] = "auto";
   root3["apps"].push_back(x2);
   changed = false;
-  purge_uninstalled_and_ttl(root3, none, no_hidden, 0, now, last_played, true, false, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
+  purge_uninstalled_and_ttl(root3, none, no_hidden, no_known, false /*library complete*/, 0, now, last_played, true, false, false /*remove uninstalled*/, true /*sync all*/, selected, changed);
   EXPECT_FALSE(changed);
   EXPECT_EQ(root3["apps"].size(), 1u);
 }


### PR DESCRIPTION
## What

Playnite records when a game was last played and for how long. The plugin has always sent both — the connector reports `lastPlayed` and `playtimeMinutes`, and the host parses them into `Game` — but they stopped there. Sync never mirrored them into `apps.json`, so nothing downstream could see them and `/appmetadata` could not serve them.

This carries them the remaining three hops, alongside the metadata passthrough that already works exactly this way:

- `playnite_sync.cpp` — mirror into `apps.json` as `playnite-last-played` / `playnite-playtime-minutes`
- `process.h` / `process.cpp` — hold and read them on `playnite_metadata_t`
- `nvhttp.cpp` — serve them from `/appmetadata`

## Why

A client can track launches on its own, but only its own. These cover sessions played at the PC itself, which is the difference between "last played" and "last launched from this device". It unblocks a "recently played" / "most played" ordering in the library that reflects reality rather than one device's history.

## Notes

- Zero playtime is treated as no playtime and erased rather than written, so `apps.json` doesn't grow a key on every never-played game.
- Both feed `present`, so a game whose only metadata is a play record now appears in `/appmetadata` instead of being withheld.
- Purely additive to the protocol: clients that don't ask for these fields are unaffected.

## Testing

⚠️ **Not built or run locally** — `playnite_sync.cpp` is Windows-only (`cmake/compile_definitions/windows.cmake`) and this was written on macOS. CI's Windows build is the first real compile. No unit test was added: the writer this touches also does Windows-only icon conversion, which is why the surrounding metadata passthrough has no test coverage either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyoALjXs9fMzqBWZm3EWjW