### PR TITLE
fix(vdd): do not initialize the virtual display driver from proc::refresh()

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -3976,18 +3976,12 @@ namespace proc {
       proc.terminate(false, false);
     }
 
-#ifdef _WIN32
-    size_t fail_count = 0;
-    while (fail_count < 5 && vDisplayDriverStatus.load(std::memory_order_acquire) != VDISPLAY::DRIVER_STATUS::OK) {
-      initVDisplayDriver();
-      if (vDisplayDriverStatus.load(std::memory_order_acquire) == VDISPLAY::DRIVER_STATUS::OK) {
-        break;
-      }
-
-      fail_count += 1;
-      std::this_thread::sleep_for(1s);
-    }
-#endif
+    // The virtual display driver is deliberately not initialized here. refresh()
+    // only parses apps.json, and it runs during startup before the HTTP and RTSP
+    // listeners exist, as well as inside web UI request handlers. Retrying a
+    // non-responsive driver from this call stack delayed the configuration UI by
+    // minutes and stalled apps.json saves. Every consumer already initializes the
+    // driver lazily when it actually needs a virtual display.
 
     auto proc_opt = proc::parse(file_name);
 


### PR DESCRIPTION
## Problem

`proc::refresh()` retried virtual display driver initialization up to five times, one second apart, on the main thread. It runs during startup before the HTTP and RTSP listeners are created, and again inside three web UI request handlers, so a driver that stops answering its control protocol delayed the configuration UI and stalled apps.json saves.

Reproduced twice on a machine where Device Manager reported the adapter healthy but the control interface never responded. The host logged its restart cycle on repeat and did not reach `Configuration UI available` within a 30 second wait.

## Change

Remove the loop. `refresh()` parses apps.json and nothing in it needs a virtual display, and every consumer already initializes the driver lazily when it actually needs one. Vibeshine has no equivalent loop, so this converges on that structure rather than adapting the fork-local behavior.

## Scope

This started as three changes. The other two adjusted Vibepollo's restart cooldown handling and added a total time budget to `ensure_driver_is_ready_impl`. Both have been dropped: they patch a recovery structure that has drifted from Vibeshine, which already solves cancellation properly with `std::stop_token` and `open_vdisplay_device_impl(stop_token)` that Vibepollo does not carry at all. Converging those two implementations is a larger piece of work that belongs in Vibeshine first, so it is deliberately not attempted here.
