### PR TITLE
fix(nvhttp): return the certificate response in PIN-stdin pairing

### DIFF
--- a/src/nvhttp.cpp
+++ b/src/nvhttp.cpp
@@ -2033,7 +2033,10 @@ namespace nvhttp {
             deviceName = "Legacy Moonlight Client";
           }
 
-          sess.client.uniqueID = std::move(uniqID);
+          // Keep uniqID valid until this request has completed. The synchronous
+          // PIN path responds below, while later pairing phases use it to look up
+          // the session created here.
+          sess.client.uniqueID = uniqID;
           sess.client.name = std::move(deviceName);
           sess.client.cert = util::from_hex_vec(get_arg(args, "clientcert"), true);
 
@@ -2084,6 +2087,10 @@ namespace nvhttp {
             std::getline(std::cin, pin);
 
             getservercert(ptr->second, tree, pin);
+            // Respond with the certificate we just produced. Falling through
+            // would clobber this response with 'Invalid uniqueid' via the
+            // moved-from lookup below and break stdin-driven pairing.
+            return;
           } else {
 #if defined SUNSHINE_TRAY && SUNSHINE_TRAY >= 1
             system_tray::update_tray_require_pin();


### PR DESCRIPTION
## Problem

Pairing via stdin (`-0`) can never complete.

The `getservercert` phase builds its response, then falls through to the session lookup below it. That lookup reads `uniqueID` after it has been moved from, fails to find the session, and overwrites the response with `400 Invalid uniqueid`. The client therefore always sees a failure even though the certificate was produced correctly.

## Change

Keep `uniqID` alive for the duration of the request, and return once the certificate response has been written.

## How it was found

Our automated AMD latency tests pair a Moonlight client through exactly this path and could never get past pairing. The same defect is present in Apollo and has been fixed there too (ClassicOldSong/Apollo#1539).

Two lines, no behavior change for the web UI or OTP pairing paths, which return before this point.
