### PR TITLE
docs(amf): credit Foundation Sunshine for the AMD default handling

### DIFF
--- a/src/amf/amf_config.h
+++ b/src/amf/amf_config.h
@@ -1,6 +1,18 @@
 /**
  * @file src/amf/amf_config.h
  * @brief Declarations for AMF encoder configuration.
+ *
+ * Portions of the AMD aggressive-default handling in this file, specifically the
+ * opt-in treatment of LOWLATENCY_MODE, INPUT_QUEUE_SIZE and the AV1 encoding
+ * latency mode together with the rationale documented in the surrounding
+ * comments, are derived from Foundation Sunshine:
+ *
+ *   AlkaidLab/foundation-sunshine commit 3340d28 ("feat(amf): align AMD
+ *   aggressive defaults with FFmpeg amfenc", AlkaidLab/foundation-sunshine#666),
+ *   by qiin2333.
+ *
+ * Modified for Vibepollo by Ramazan Kara. Both projects are licensed under
+ * GPLv3 and that license is preserved here.
  */
 #pragma once
 

--- a/src/amf/amf_d3d11.cpp
+++ b/src/amf/amf_d3d11.cpp
@@ -1,6 +1,18 @@
 /**
  * @file src/amf/amf_d3d11.cpp
  * @brief Implementation of standalone AMF encoder with D3D11 texture input.
+ *
+ * Portions of the AMD aggressive-default handling in this file, specifically the
+ * opt-in treatment of LOWLATENCY_MODE, INPUT_QUEUE_SIZE and the AV1 encoding
+ * latency mode together with the rationale documented in the surrounding
+ * comments, are derived from Foundation Sunshine:
+ *
+ *   AlkaidLab/foundation-sunshine commit 3340d28 ("feat(amf): align AMD
+ *   aggressive defaults with FFmpeg amfenc", AlkaidLab/foundation-sunshine#666),
+ *   by qiin2333.
+ *
+ * Modified for Vibepollo by Ramazan Kara. Both projects are licensed under
+ * GPLv3 and that license is preserved here.
  */
 
 #include "amf_d3d11.h"


### PR DESCRIPTION
Adds the Foundation Sunshine attribution that was missing from the native AMD encoder, raised in #342.

## What was verified

Comparing [AlkaidLab/foundation-sunshine@3340d28](https://github.com/AlkaidLab/foundation-sunshine/commit/3340d28450681211eced563b7c659edb41f285a7) against this tree, 37 comment lines added by that commit appear verbatim here: 25 in `src/amf/amf_d3d11.cpp` and 12 in `src/amf/amf_config.h`.

That covers the opt-in treatment of `LOWLATENCY_MODE`, `INPUT_QUEUE_SIZE` and the AV1 encoding latency mode, together with the rationale explaining why forcing those properties exposed driver freezes on RDNA4, including the reference to AlkaidLab/foundation-sunshine#666.

The code itself was adapted rather than copied line for line, since this version routes the properties through verified setters, but the design decision and the reasoning behind it came from Foundation.

## Change

A provenance notice in the header of both affected files naming the source commit, its author, and the GPLv3 license both projects share. No functional change.
