### PR TITLE
fix(display): refresh portrait rotation after restore

### DIFF
--- a/src/platform/windows/display_helper_v2/interfaces.h
+++ b/src/platform/windows/display_helper_v2/interfaces.h
@@ -124,7 +124,8 @@ namespace display_helper::v2 {
     }
 
     /// Apply per-device rotations (batched, mirrors legacy CDS_NORESET commit).
-    virtual bool apply_layout_rotations(const codec::layout_rotation_map_t &) {
+    virtual bool apply_layout_rotations(const codec::layout_rotation_map_t &, bool force_reassert_matching = false) {
+      (void) force_reassert_matching;
       return true;
     }
 

--- a/src/platform/windows/display_helper_v2/operations.cpp
+++ b/src/platform/windows/display_helper_v2/operations.cpp
@@ -902,10 +902,23 @@ namespace display_helper::v2 {
       return false;
     }
     const bool layout_ok = !loaded.has_layout_data || display_.current_layout_matches(loaded.layout_rotations);
-    const bool ok = got_stable && codec::equal_snapshots_strict(cur, loaded.snapshot) && layout_ok &&
-                    quiet_period(std::chrono::milliseconds(750), std::chrono::milliseconds(150), token);
+    bool ok = got_stable && codec::equal_snapshots_strict(cur, loaded.snapshot) && layout_ok &&
+              quiet_period(std::chrono::milliseconds(750), std::chrono::milliseconds(150), token);
+    if (ok && loaded.has_layout_data && !loaded.layout_rotations.empty()) {
+      if (token.is_cancelled()) {
+        return false;
+      }
+      // Windows can report the expected portrait orientation after a virtual-display
+      // teardown while a GPU driver's pointer transform is still stale. Reasserting
+      // the saved rotations gives the driver a display-change notification without
+      // replaying the complete topology restore.
+      ok = display_.apply_layout_rotations(loaded.layout_rotations, true);
+      if (!ok) {
+        BOOST_LOG(warning) << "Restore (" << label << "): failed to refresh matching display rotations.";
+      }
+    }
     if (ok) {
-      BOOST_LOG(info) << "Restore (" << label << "): current state already matches baseline; skipping apply.";
+      BOOST_LOG(info) << "Restore (" << label << "): current state already matches baseline; skipping full apply.";
     }
     return ok;
   }

--- a/src/platform/windows/display_helper_v2/snapshot.cpp
+++ b/src/platform/windows/display_helper_v2/snapshot.cpp
@@ -127,12 +127,38 @@ namespace display_helper::v2 {
     return it->second;
   }
 
+  std::optional<codec::ParsedSnapshot> InMemorySnapshotStorage::load_with_metadata(SnapshotTier tier) {
+    auto snapshot = load(tier);
+    if (!snapshot) {
+      return std::nullopt;
+    }
+
+    codec::ParsedSnapshot loaded;
+    loaded.snapshot = std::move(*snapshot);
+    loaded.snapshot_version = codec::kSnapshotLayoutVersionLatest;
+    if (auto it = layout_rotations_.find(tier); it != layout_rotations_.end()) {
+      loaded.layout_rotations = it->second;
+    }
+    return loaded;
+  }
+
   bool InMemorySnapshotStorage::save(SnapshotTier tier, const Snapshot &snapshot) {
     snapshots_[tier] = snapshot;
+    layout_rotations_.erase(tier);
+    return true;
+  }
+
+  bool InMemorySnapshotStorage::save(
+    SnapshotTier tier,
+    const Snapshot &snapshot,
+    const codec::layout_rotation_map_t &layout_rotations) {
+    snapshots_[tier] = snapshot;
+    layout_rotations_[tier] = layout_rotations;
     return true;
   }
 
   bool InMemorySnapshotStorage::remove(SnapshotTier tier) {
+    layout_rotations_.erase(tier);
     return snapshots_.erase(tier) > 0;
   }
 

--- a/src/platform/windows/display_helper_v2/snapshot.h
+++ b/src/platform/windows/display_helper_v2/snapshot.h
@@ -41,7 +41,9 @@ namespace display_helper::v2 {
   class InMemorySnapshotStorage : public ISnapshotStorage {
   public:
     std::optional<Snapshot> load(SnapshotTier tier) override;
+    std::optional<codec::ParsedSnapshot> load_with_metadata(SnapshotTier tier) override;
     bool save(SnapshotTier tier, const Snapshot &snapshot) override;
+    bool save(SnapshotTier tier, const Snapshot &snapshot, const codec::layout_rotation_map_t &layout_rotations) override;
     bool remove(SnapshotTier tier) override;
     std::vector<std::string> missing_devices(
       const Snapshot &snapshot,
@@ -49,6 +51,7 @@ namespace display_helper::v2 {
 
   private:
     std::map<SnapshotTier, Snapshot> snapshots_;
+    std::map<SnapshotTier, codec::layout_rotation_map_t> layout_rotations_;
   };
 
   class SnapshotService {

--- a/src/platform/windows/display_helper_v2/win_display_settings.cpp
+++ b/src/platform/windows/display_helper_v2/win_display_settings.cpp
@@ -855,7 +855,10 @@ namespace display_helper::v2 {
       bool already_correct = false;
     };
 
-    std::optional<PreparedRotation> prepare_display_rotation(const std::wstring &display_name, int degrees) {
+    std::optional<PreparedRotation> prepare_display_rotation(
+      const std::wstring &display_name,
+      int degrees,
+      bool force_reassert_matching) {
       if (display_name.empty()) {
         return std::nullopt;
       }
@@ -870,13 +873,18 @@ namespace display_helper::v2 {
       }
       auto *mode = reinterpret_cast<DEVMODEW *>(buf.data());
 
-      if (mode->dmDisplayOrientation == *target) {
+      if (mode->dmDisplayOrientation == *target &&
+          (!force_reassert_matching || *target == DMDO_DEFAULT)) {
         return PreparedRotation {display_name, {}, true};
       }
 
       const bool swap_axes = ((mode->dmDisplayOrientation + *target) % 2) == 1;
       mode->dmFields = DM_DISPLAYORIENTATION | DM_POSITION;
       mode->dmDisplayOrientation = *target;
+      // A non-default orientation must be submitted even when Windows already
+      // reports the requested value. After a virtual display is removed, some
+      // GPU drivers retain the virtual output's pointer transform until the
+      // portrait mode is explicitly reasserted.
       if (swap_axes) {
         std::swap(mode->dmPelsWidth, mode->dmPelsHeight);
         mode->dmFields |= DM_PELSWIDTH | DM_PELSHEIGHT;
@@ -940,7 +948,9 @@ namespace display_helper::v2 {
     return out;
   }
 
-  bool WinDisplaySettings::apply_layout_rotations(const codec::layout_rotation_map_t &layout_rotations) {
+  bool WinDisplaySettings::apply_layout_rotations(
+    const codec::layout_rotation_map_t &layout_rotations,
+    bool force_reassert_matching) {
     if (layout_rotations.empty()) {
       return true;
     }
@@ -962,7 +972,7 @@ namespace display_helper::v2 {
         continue;
       }
 
-      auto prepared = prepare_display_rotation(it->second, rotation);
+      auto prepared = prepare_display_rotation(it->second, rotation, force_reassert_matching);
       if (!prepared) {
         BOOST_LOG(warning) << "Layout restore: failed to prepare rotation for " << device_id
                            << " (" << rotation << " degrees)";

--- a/src/platform/windows/display_helper_v2/win_display_settings.h
+++ b/src/platform/windows/display_helper_v2/win_display_settings.h
@@ -50,7 +50,9 @@ namespace display_helper::v2 {
     bool reset_staged_apply_state() override;
     bool is_primary_device(const std::string &device_id) override;
     codec::layout_rotation_map_t capture_layout_rotations(const std::set<std::string> &device_ids) override;
-    bool apply_layout_rotations(const codec::layout_rotation_map_t &layout_rotations) override;
+    bool apply_layout_rotations(
+      const codec::layout_rotation_map_t &layout_rotations,
+      bool force_reassert_matching = false) override;
     bool current_layout_matches(const codec::layout_rotation_map_t &expected) override;
     bool set_device_refresh_rate(const std::string &device_id, unsigned int num, unsigned int den) override;
     std::optional<display_device::Resolution> get_display_resolution(const std::string &device_id) override;

--- a/tests/unit/platform/windows/test_virtual_display_sunshine.cpp
+++ b/tests/unit/platform/windows/test_virtual_display_sunshine.cpp
@@ -171,6 +171,20 @@ TEST(SunshineVirtualDisplay, ActivePhysicalDisplayDetectionIsScopedToConfiguredA
   expect_contains(misc_source, "if (config::video.adapter_name.empty()) {");
 }
 
+TEST(SunshineVirtualDisplay, MatchingPortraitRotationIsReassertedDuringRestore) {
+  const auto source = read_source("src/platform/windows/display_helper_v2/win_display_settings.cpp");
+  const auto prepare_pos = source.find("prepare_display_rotation(");
+  ASSERT_NE(prepare_pos, std::string::npos);
+  const auto prepare_end = source.find("}  // namespace", prepare_pos);
+  ASSERT_NE(prepare_end, std::string::npos);
+  const auto prepare_body = source.substr(prepare_pos, prepare_end - prepare_pos);
+
+  // Landscape may be skipped when already correct. Portrait and inverted
+  // orientations must still reach ChangeDisplaySettingsEx so GPU drivers can
+  // refresh a stale pointer transform after virtual-display teardown.
+  expect_contains(prepare_body, "!force_reassert_matching || *target == DMDO_DEFAULT");
+}
+
 TEST(SunshineVirtualDisplay, ConfiguredRenderAdapterIsNeverSilentlyReplaced) {
   for (const auto &relative_path : {
          std::string {"src/platform/windows/virtual_display_sunshine.cpp"},

--- a/tests/unit/test_display_helper_v2_restore_engine.cpp
+++ b/tests/unit/test_display_helper_v2_restore_engine.cpp
@@ -367,6 +367,10 @@ namespace {
 
     void sleep_for(std::chrono::milliseconds duration) override {
       now_ += duration;
+      ++sleep_calls;
+      if (on_sleep) {
+        on_sleep(sleep_calls);
+      }
     }
 
     void advance(std::chrono::milliseconds duration) {
@@ -375,6 +379,10 @@ namespace {
 
   private:
     std::chrono::steady_clock::time_point now_ {std::chrono::steady_clock::now() + std::chrono::hours(1)};
+
+  public:
+    int sleep_calls = 0;
+    std::function<void(int)> on_sleep;
   };
 
   /// Stateful display fake: topology and settings are distinct operations so
@@ -459,6 +467,15 @@ namespace {
       return reset_staged_apply_state_result;
     }
 
+    bool apply_layout_rotations(
+      const codec::layout_rotation_map_t &layouts,
+      bool force_reassert_matching = false) override {
+      ++layout_apply_calls;
+      last_applied_layouts = layouts;
+      last_force_reassert_matching = force_reassert_matching;
+      return layout_apply_result;
+    }
+
     static std::string first_id(const display_device::DisplaySettingsSnapshot &snapshot) {
       return first_id(snapshot.m_topology);
     }
@@ -479,7 +496,11 @@ namespace {
     int topology_calls = 0;
     int enumerate_calls = 0;
     int reset_staged_apply_state_calls = 0;
+    int layout_apply_calls = 0;
     bool reset_staged_apply_state_result = true;
+    bool layout_apply_result = true;
+    bool last_force_reassert_matching = false;
+    codec::layout_rotation_map_t last_applied_layouts;
     std::function<void()> on_topology_applied;
     std::function<void()> on_enumerate;
   };
@@ -519,6 +540,61 @@ TEST(DisplayHelperV2RecoveryEngine, TerminatesWithoutApplyOnFirstConfirmedMatch)
   EXPECT_TRUE(outcome.success);
   EXPECT_EQ(harness.display.apply_calls, 0);
   EXPECT_EQ(harness.display.reset_staged_apply_state_calls, 1);
+}
+
+TEST(DisplayHelperV2RecoveryEngine, ReassertsMatchingPortraitLayoutWithoutFullRestore) {
+  RecoveryHarness harness;
+  harness.add_device("A");
+
+  const auto baseline = make_snapshot({{"A"}});
+  const codec::layout_rotation_map_t layouts {{"A", 90}};
+  ASSERT_TRUE(harness.storage.save(display_helper::v2::SnapshotTier::Current, baseline, layouts));
+  harness.display.current = baseline;
+
+  const auto outcome = harness.recovery.run(harness.cancellation.token());
+
+  EXPECT_TRUE(outcome.success);
+  EXPECT_EQ(harness.display.apply_calls, 0);
+  EXPECT_EQ(harness.display.topology_calls, 0);
+  EXPECT_EQ(harness.display.layout_apply_calls, 1);
+  EXPECT_EQ(harness.display.last_applied_layouts, layouts);
+  EXPECT_TRUE(harness.display.last_force_reassert_matching);
+}
+
+TEST(DisplayHelperV2RecoveryEngine, CancellationAfterQuietPeriodSkipsRotationRefresh) {
+  RecoveryHarness harness;
+  harness.add_device("A");
+
+  const auto baseline = make_snapshot({{"A"}});
+  const codec::layout_rotation_map_t layouts {{"A", 90}};
+  ASSERT_TRUE(harness.storage.save(display_helper::v2::SnapshotTier::Current, baseline, layouts));
+  harness.display.current = baseline;
+  harness.clock.on_sleep = [&](int sleep_calls) {
+    if (sleep_calls == 7) {
+      harness.cancellation.cancel();
+    }
+  };
+
+  const auto outcome = harness.recovery.run(harness.cancellation.token());
+
+  EXPECT_FALSE(outcome.success);
+  EXPECT_EQ(harness.display.layout_apply_calls, 0);
+}
+
+TEST(DisplayHelperV2RecoveryEngine, FullRestoreDoesNotForceMatchingRotationRefresh) {
+  RecoveryHarness harness;
+  harness.add_device("A");
+
+  const auto baseline = make_snapshot({{"A"}});
+  const codec::layout_rotation_map_t layouts {{"A", 90}};
+  ASSERT_TRUE(harness.storage.save(display_helper::v2::SnapshotTier::Current, baseline, layouts));
+  harness.display.current = make_snapshot({{"B"}});
+
+  const auto outcome = harness.recovery.run(harness.cancellation.token());
+
+  EXPECT_TRUE(outcome.success);
+  EXPECT_EQ(harness.display.layout_apply_calls, 1);
+  EXPECT_FALSE(harness.display.last_force_reassert_matching);
 }
 
 TEST(DisplayHelperV2RecoveryEngine, StopsBeforeSettingsWhenTopologyStageIsCancelled) {


### PR DESCRIPTION
## Problem

Fixes #406.

After an exclusive virtual-display session ends on a hybrid-GPU Windows laptop, a portrait physical display can be visibly restored while its local pointer transform remains rotated. The helper reports `layout_match=true`, and the saved snapshot correctly contains `rotation: 270`, but pointer movement stays mapped to the wrong orientation until the same rotation is reapplied in NVIDIA Control Panel.

The issue reproduces when capture is pinned to `NVIDIA GeForce RTX 5070 Ti Laptop GPU`. Switching only the capture adapter to Automatic prevents it.

## Root cause

Recovery skips display application when the current topology, modes, and saved rotations already match. That fast path normally avoids unnecessary display changes, but Windows can report the expected portrait orientation before the GPU driver refreshes its pointer transform. The matching-state check cannot observe that driver-side stale state.

`apply_layout_rotations()` also skipped displays whose orientation already equaled the saved value, so the restore never sent the driver another display-change notification.

## Fix

- Reassert saved rotations when a snapshot confirms through the matching-state fast path without replaying the full topology.
- Continue skipping an already-correct landscape orientation.
- Resubmit matching 90, 180, and 270 degree orientations through `ChangeDisplaySettingsExW`, preserving the existing batched multi-display path.
- Check cancellation immediately before the refresh.
- Keep ordinary full-restore rotation application unchanged.
- Treat a failed matching-state rotation refresh as a retryable restore failure.

## Verification

- Reproduced on `1.18.4-stable.2` with Windows 25H2 and an RTX 5070 Ti Laptop GPU.
- Confirmed the affected restore reported `layout_match=true` while the saved layout contained the correct `270` degree rotation.
- Added recovery-engine coverage for matching portrait refresh, cancellation before refresh, and unchanged full-restore behavior.
- Added a Windows contract regression verifying that matching portrait rotations reach the display-change path.
- Windows CI passed for commit `3278f353`: https://github.com/ree9622/Vibepollo/actions/runs/31372353843
- Hardware validation passed with Adapter Name pinned to the RTX 5070 Ti and an exclusive virtual-display session. After disconnect, portrait pointer movement was correct without reapplying rotation in NVIDIA Control Panel.
- During the same validation, a previously observed fallback to the lowest available physical-display resolution also did not recur; the display returned at the expected saved resolution.
- `git diff --check` passes.

The hardware test used the Windows installer built directly from this PR branch at `3278f353`.