### PR TITLE
fix(audio): restore physical endpoint after stream teardown

### DIFF
--- a/src/audio_policy.cpp
+++ b/src/audio_policy.cpp
@@ -4,6 +4,8 @@
  */
 #include "audio_policy.h"
 
+#include <algorithm>
+
 namespace audio::policy {
   int stream_index(int channels, bool high_quality) {
     const int quality_offset = high_quality ? 1 : 0;
@@ -46,6 +48,73 @@ namespace audio::policy {
       }
     }
     return selected;
+  }
+
+  bool is_steam_streaming_render_adapter(std::string_view adapter_name) {
+    return adapter_name == "Steam Streaming Speakers" ||
+           adapter_name == "Steam Streaming Microphone";
+  }
+
+  render_endpoint_catalog_t build_render_endpoint_catalog(
+    bool discovery_complete,
+    const std::vector<render_endpoint_t> &endpoints
+  ) {
+    render_endpoint_catalog_t catalog {
+      discovery_complete,
+      endpoints,
+      {},
+      {},
+    };
+    for (const auto &endpoint : endpoints) {
+      if (!endpoint.active) {
+        continue;
+      }
+      if (endpoint.id.empty() || endpoint.adapter_name.empty()) {
+        catalog.complete = false;
+        continue;
+      }
+      if (is_steam_streaming_render_adapter(endpoint.adapter_name)) {
+        catalog.steam_endpoint_ids.push_back(endpoint.id);
+      } else {
+        catalog.eligible_non_steam_endpoint_ids.push_back(endpoint.id);
+      }
+    }
+    return catalog;
+  }
+
+  std::optional<std::string> select_eligible_non_steam_render_endpoint(
+    const render_endpoint_catalog_t &catalog,
+    const std::vector<std::string> &preferred_ids
+  ) {
+    if (!catalog.complete) {
+      return std::nullopt;
+    }
+
+    for (const auto &preferred_id : preferred_ids) {
+      if (!preferred_id.empty() &&
+          std::find(
+            catalog.eligible_non_steam_endpoint_ids.begin(),
+            catalog.eligible_non_steam_endpoint_ids.end(),
+            preferred_id
+          ) != catalog.eligible_non_steam_endpoint_ids.end()) {
+        return preferred_id;
+      }
+    }
+
+    if (!catalog.eligible_non_steam_endpoint_ids.empty()) {
+      return catalog.eligible_non_steam_endpoint_ids.front();
+    }
+    return std::nullopt;
+  }
+
+  std::optional<std::string> select_eligible_non_steam_render_endpoint(
+    const std::vector<render_endpoint_t> &endpoints,
+    const std::vector<std::string> &preferred_ids
+  ) {
+    return select_eligible_non_steam_render_endpoint(
+      build_render_endpoint_catalog(true, endpoints),
+      preferred_ids
+    );
   }
 
   sample_action_e sample_action(sample_status_e status) {

--- a/src/audio_policy.h
+++ b/src/audio_policy.h
@@ -8,6 +8,8 @@
 #include <cstddef>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace audio::policy {
   struct stream_layout_t {
@@ -31,6 +33,33 @@ namespace audio::policy {
                           const std::string &configured_sink,
                           int channels,
                           bool host_audio_enabled);
+
+  struct render_endpoint_t {
+    std::string id;
+    std::string adapter_name;
+    bool active;
+  };
+
+  struct render_endpoint_catalog_t {
+    bool complete;
+    std::vector<render_endpoint_t> endpoints;
+    std::vector<std::string> steam_endpoint_ids;
+    std::vector<std::string> eligible_non_steam_endpoint_ids;
+  };
+
+  bool is_steam_streaming_render_adapter(std::string_view adapter_name);
+  render_endpoint_catalog_t build_render_endpoint_catalog(
+    bool discovery_complete,
+    const std::vector<render_endpoint_t> &endpoints
+  );
+  std::optional<std::string> select_eligible_non_steam_render_endpoint(
+    const render_endpoint_catalog_t &catalog,
+    const std::vector<std::string> &preferred_ids
+  );
+  std::optional<std::string> select_eligible_non_steam_render_endpoint(
+    const std::vector<render_endpoint_t> &endpoints,
+    const std::vector<std::string> &preferred_ids
+  );
 
   enum class sample_status_e {
     ok,

--- a/src/platform/windows/audio.cpp
+++ b/src/platform/windows/audio.cpp
@@ -5,6 +5,7 @@
 #define INITGUID
 
 // standard includes
+#include <algorithm>
 #include <atomic>
 #include <array>
 #include <cstdint>
@@ -27,6 +28,7 @@
 
 // local includes
 #include "src/config.h"
+#include "src/audio_policy.h"
 #include "src/logging.h"
 #include "src/platform/common.h"
 #include "utf_utils.h"
@@ -826,13 +828,21 @@ namespace platf::audio {
         return std::nullopt;
       }
 
-      auto matched_steam = find_device_id(match_steam_speakers());
-      if (matched_steam && host_id == matched_steam->second) {
-        auto pending_preferred_id = pending_preferred_restore_id();
-        if (pending_preferred_id) {
-          host_id = *pending_preferred_id;
+      const auto endpoint_catalog = active_render_endpoint_catalog();
+      const auto steam_device_ids = steam_render_device_ids(endpoint_catalog);
+      if (endpoint_catalog.complete && contains_device_id(steam_device_ids, host_id)) {
+        std::vector<std::wstring> preferred_ids;
+        if (const auto pending_id = pending_preferred_restore_id()) {
+          preferred_ids.push_back(*pending_id);
         }
-      } else {
+        if (const auto replacement = active_non_steam_render_endpoint(endpoint_catalog, preferred_ids)) {
+          for (auto &default_id : default_device_ids) {
+            if (contains_device_id(steam_device_ids, default_id)) {
+              default_id = *replacement;
+            }
+          }
+        }
+      } else if (endpoint_catalog.complete) {
         clear_pending_preferred_restore();
       }
 
@@ -1011,9 +1021,12 @@ namespace platf::audio {
       const auto assignment_epoch = pending_restore_handoff.assignment_epoch;
       pending_role_restores_t transferred_role_restores;
       if (!pending_restore_handoff.role_restores.empty()) {
+        const auto transfer_catalog = active_render_endpoint_catalog();
         transferred_role_restores = normalize_pending_role_restores(
           std::move(pending_restore_handoff.role_restores),
-          pending_restore_handoff.steam_device_id,
+          transfer_catalog.complete ?
+            steam_render_device_ids(transfer_catalog) :
+            std::vector<std::wstring> {},
           current_default_ids
         );
       }
@@ -1167,6 +1180,111 @@ namespace platf::audio {
       };
     }
 
+    ::audio::policy::render_endpoint_catalog_t active_render_endpoint_catalog() {
+      collection_t collection;
+      const auto status = device_enum->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, &collection);
+      if (FAILED(status) || !collection) {
+        BOOST_LOG(error) << "Couldn't enumerate active render endpoints: [0x"sv
+                         << util::hex(status).to_string_view() << ']';
+        return ::audio::policy::build_render_endpoint_catalog(false, {});
+      }
+
+      UINT count = 0;
+      const auto count_status = collection->GetCount(&count);
+      if (FAILED(count_status)) {
+        BOOST_LOG(error) << "Couldn't count active render endpoints: [0x"sv
+                         << util::hex(count_status).to_string_view() << ']';
+        return ::audio::policy::build_render_endpoint_catalog(false, {});
+      }
+
+      bool complete = true;
+      std::vector<::audio::policy::render_endpoint_t> endpoints;
+      endpoints.reserve(count);
+      for (UINT index = 0; index < count; ++index) {
+        audio::device_t device;
+        if (FAILED(collection->Item(index, &device)) || !device) {
+          complete = false;
+          continue;
+        }
+
+        audio::wstring_t device_id;
+        if (FAILED(device->GetId(&device_id)) || !device_id) {
+          complete = false;
+          continue;
+        }
+
+        std::string adapter_name;
+        audio::prop_t properties;
+        const auto property_status = device->OpenPropertyStore(STGM_READ, &properties);
+        if (SUCCEEDED(property_status) && properties) {
+          prop_var_t adapter_friendly_name;
+          if (SUCCEEDED(properties->GetValue(PKEY_DeviceInterface_FriendlyName, &adapter_friendly_name.prop)) &&
+              adapter_friendly_name.prop.vt == VT_LPWSTR &&
+              adapter_friendly_name.prop.pwszVal &&
+              adapter_friendly_name.prop.pwszVal[0] != L'\0') {
+            adapter_name = utf_utils::to_utf8(adapter_friendly_name.prop.pwszVal);
+          } else {
+            complete = false;
+          }
+        } else {
+          complete = false;
+        }
+
+        endpoints.push_back({
+          utf_utils::to_utf8(device_id.get()),
+          std::move(adapter_name),
+          true,
+        });
+      }
+
+      auto catalog = ::audio::policy::build_render_endpoint_catalog(complete, endpoints);
+      if (!catalog.complete) {
+        BOOST_LOG(warning) << "Active render endpoint discovery was incomplete; skipping Steam audio recovery policy writes"sv;
+      }
+      return catalog;
+    }
+
+    static std::vector<std::wstring> steam_render_device_ids(
+      const ::audio::policy::render_endpoint_catalog_t &catalog
+    ) {
+      std::vector<std::wstring> ids;
+      ids.reserve(catalog.steam_endpoint_ids.size());
+      for (const auto &device_id : catalog.steam_endpoint_ids) {
+        ids.push_back(utf_utils::from_utf8(device_id));
+      }
+      return ids;
+    }
+
+    static bool contains_device_id(
+      const std::vector<std::wstring> &device_ids,
+      const std::wstring &device_id
+    ) {
+      return !device_id.empty() &&
+             std::find(device_ids.begin(), device_ids.end(), device_id) != device_ids.end();
+    }
+
+    std::optional<std::wstring> active_non_steam_render_endpoint(
+      const ::audio::policy::render_endpoint_catalog_t &catalog,
+      const std::vector<std::wstring> &preferred_ids
+    ) {
+      std::vector<std::string> preferred_utf8;
+      preferred_utf8.reserve(preferred_ids.size());
+      for (const auto &preferred_id : preferred_ids) {
+        if (!preferred_id.empty()) {
+          preferred_utf8.push_back(utf_utils::to_utf8(preferred_id.c_str()));
+        }
+      }
+
+      const auto selected = ::audio::policy::select_eligible_non_steam_render_endpoint(
+        catalog,
+        preferred_utf8
+      );
+      if (!selected) {
+        return std::nullopt;
+      }
+      return utf_utils::from_utf8(*selected);
+    }
+
     static std::mutex &preferred_restore_cache_mutex_ref() {
       static std::mutex mutex;
       return mutex;
@@ -1228,7 +1346,7 @@ namespace platf::audio {
 
     static pending_role_restores_t normalize_pending_role_restores(
       pending_role_restores_t role_restores,
-      const std::wstring &steam_device_id,
+      const std::vector<std::wstring> &steam_device_ids,
       const role_device_ids_t &current_default_ids
     ) {
       pending_role_restores_t normalized;
@@ -1242,12 +1360,11 @@ namespace platf::audio {
         const bool retained_endpoint =
           current_id == role_restore.expected_current_id ||
           current_id == role_restore.preferred_id;
-        const bool worker_fallback_transition =
-          role_restore.fallback_transition &&
-          !steam_device_id.empty() &&
-          role_restore.expected_current_id == steam_device_id;
-        if (!retained_endpoint && !worker_fallback_transition) {
-          // A mismatch outside the worker-published visibility transition is a
+        const bool retained_steam_topology =
+          contains_device_id(steam_device_ids, role_restore.expected_current_id) &&
+          contains_device_id(steam_device_ids, current_id);
+        if (!retained_endpoint && !retained_steam_topology) {
+          // A mismatch outside the product-owned Steam topology is a
           // newer user or system choice. Never replace it with the old target.
           continue;
         }
@@ -1958,7 +2075,7 @@ namespace platf::audio {
           continue;
         }
 
-        if (retry_fallback_reset && is_default_device(steam_device_id)) {
+        if (retry_fallback_reset) {
           auto fallback_result = try_reset_from_steam(
             steam_device_id,
             assignment_epoch,
@@ -1977,8 +2094,6 @@ namespace platf::audio {
           if (fallback_result == reset_result_e::no_device) {
             retry_fallback_reset = false;
           }
-        } else if (retry_fallback_reset && !try_preferred_restore) {
-          return;
         }
 
         // If notification registration failed, use the timed wait as a polling
@@ -1998,39 +2113,86 @@ namespace platf::audio {
         return;
       }
 
-      auto matched_steam = find_device_id(match_steam_speakers());
-      std::wstring steam_device_id = inherited_handoff.steam_device_id;
-      if (matched_steam) {
-        steam_device_id = matched_steam->second;
+      const auto catalog = active_render_endpoint_catalog();
+      if (!catalog.complete) {
+        const auto current_default_ids = current_default_device_ids();
+        auto role_restores = normalize_pending_role_restores(
+          std::move(inherited_handoff.role_restores),
+          {},
+          current_default_ids
+        );
+        if (!assigned_device_id.empty()) {
+          for (int x = 0; x < static_cast<int>(ERole_enum_count); ++x) {
+            const auto role = static_cast<ERole>(x);
+            const auto already_queued = std::any_of(
+              role_restores.begin(),
+              role_restores.end(),
+              [role](const auto &restore) {
+                return restore.role == role;
+              }
+            );
+            if (already_queued || current_default_ids[role_index(role)] != assigned_device_id) {
+              continue;
+            }
+            const auto &captured_id = captured_default_device_ids[role_index(role)];
+            role_restores.push_back({
+              role,
+              captured_id == assigned_device_id ? std::wstring {} : captured_id,
+              assigned_device_id,
+            });
+          }
+        }
+        if (!role_restores.empty()) {
+          start_pending_role_restore_task(
+            inherited_handoff.steam_device_id.empty() ?
+              assigned_device_id :
+              inherited_handoff.steam_device_id,
+            std::move(role_restores),
+            inherited_handoff.assignment_epoch
+          );
+        }
+        return;
       }
-      if (steam_device_id.empty()) {
+      const auto steam_device_ids = steam_render_device_ids(catalog);
+      std::wstring steam_device_id = inherited_handoff.steam_device_id;
+      for (const auto &endpoint : catalog.endpoints) {
+        if (endpoint.active && endpoint.adapter_name == "Steam Streaming Speakers") {
+          steam_device_id = utf_utils::from_utf8(endpoint.id);
+          break;
+        }
+      }
+      if (steam_device_ids.empty()) {
         clear_pending_preferred_restore_for_assignment(
           inherited_handoff.assignment_epoch
         );
         return;
       }
+      if (steam_device_id.empty()) {
+        steam_device_id = steam_device_ids.front();
+      }
 
       auto current_default_ids = current_default_device_ids();
       pending_role_restores_t role_restores;
-      if (assigned_device_id == steam_device_id) {
+      if (contains_device_id(steam_device_ids, assigned_device_id)) {
         for (int x = 0; x < static_cast<int>(ERole_enum_count); ++x) {
           const auto role = static_cast<ERole>(x);
-          if (current_default_ids[role_index(role)] != assigned_device_id) {
+          const auto &current_id = current_default_ids[role_index(role)];
+          if (!contains_device_id(steam_device_ids, current_id)) {
             continue;
           }
 
           const auto &captured_device_id = captured_default_device_ids[role_index(role)];
           role_restores.push_back({
             role,
-            captured_device_id == assigned_device_id ? std::wstring {} : captured_device_id,
-            assigned_device_id,
+            contains_device_id(steam_device_ids, captured_device_id) ? std::wstring {} : captured_device_id,
+            current_id,
           });
         }
       }
 
       auto inherited_role_restores = normalize_pending_role_restores(
         std::move(inherited_handoff.role_restores),
-        inherited_handoff.steam_device_id,
+        steam_device_ids,
         current_default_ids
       );
       for (auto &inherited_restore : inherited_role_restores) {
@@ -2053,8 +2215,8 @@ namespace platf::audio {
         return;
       }
 
-      // SetEndpointVisibility() is an unbounded RPC into the Windows audio
-      // service, so keep every role-specific fallback off the session thread.
+      // Audio policy calls can block in the Windows audio service, so keep
+      // every role-specific fallback off the session thread.
       start_pending_role_restore_task(
         steam_device_id,
         std::move(role_restores),
@@ -2063,18 +2225,32 @@ namespace platf::audio {
     }
 
     void reset_default_device_impl(bool wait_for_device, const std::wstring &preferred_id) {
-      auto assignment_handoff = begin_policy_assignment(current_default_device_ids());
-      const auto assignment_epoch = assignment_handoff.assignment_epoch;
-
-      auto matched_steam = find_device_id(match_steam_speakers());
-      if (!matched_steam) {
+      const auto catalog = active_render_endpoint_catalog();
+      if (!catalog.complete) {
         return;
       }
-      auto steam_device_id = matched_steam->second;
+      const auto steam_device_ids = steam_render_device_ids(catalog);
+      if (steam_device_ids.empty()) {
+        return;
+      }
 
-      // If the user already switched away from Steam speakers, leave the newer
-      // default alone instead of restoring the previously recorded endpoint.
-      if (!is_default_device(steam_device_id)) {
+      const auto current_default_ids = current_default_device_ids();
+      auto assignment_handoff = begin_policy_assignment(current_default_ids);
+      const auto assignment_epoch = assignment_handoff.assignment_epoch;
+
+      std::wstring steam_device_id;
+      const auto &console_id = current_default_ids[role_index(eConsole)];
+      if (contains_device_id(steam_device_ids, console_id)) {
+        steam_device_id = console_id;
+      } else {
+        for (const auto &current_id : current_default_ids) {
+          if (contains_device_id(steam_device_ids, current_id)) {
+            steam_device_id = current_id;
+            break;
+          }
+        }
+      }
+      if (steam_device_id.empty()) {
         clear_pending_preferred_restore_for_assignment(assignment_epoch);
         return;
       }
@@ -2082,13 +2258,15 @@ namespace platf::audio {
       // Avoid restoring back to Steam speakers if that's somehow what got
       // recorded as the original host sink.
       std::wstring effective_preferred_id = preferred_id;
-      if (effective_preferred_id.empty() || effective_preferred_id == steam_device_id) {
+      if (effective_preferred_id.empty() || contains_device_id(steam_device_ids, effective_preferred_id)) {
         auto pending_preferred_id = pending_preferred_restore_id();
         if (pending_preferred_id) {
           effective_preferred_id = *pending_preferred_id;
         }
       }
-      bool try_preferred_restore = !effective_preferred_id.empty() && effective_preferred_id != steam_device_id;
+      bool try_preferred_restore =
+        !effective_preferred_id.empty() &&
+        !contains_device_id(steam_device_ids, effective_preferred_id);
 
       if (try_preferred_restore) {
         if (!remember_pending_preferred_restore_for_assignment(
@@ -2125,9 +2303,8 @@ namespace platf::audio {
         }
       }
 
-      // SetEndpointVisibility() is an unbounded RPC into the Windows audio
-      // service. Keep it off the session audio thread so a stalled policy call
-      // cannot prevent session teardown from completing.
+      // Keep policy writes off the session audio thread so a stalled audio
+      // service call cannot prevent session teardown from completing.
       if (wait_for_device) {
         start_pending_restore_task(steam_device_id, {}, assignment_epoch);
         return;
@@ -2170,15 +2347,15 @@ namespace platf::audio {
 
     /**
      * @brief Attempts to set a specific device as the default for the roles
-     * Steam Streaming Speakers still owns.
+     * either Steam render endpoint still owns.
      * Used to restore the user's original default device after a streaming
      * session ends. Verifies the device is currently active before touching the
      * policy so we don't bind to a missing endpoint. Only the roles that are
-     * still assigned to Steam speakers are rewritten. A role the user points at
+     * still assigned to the Steam topology are rewritten. A role the user points at
      * another endpoint (commonly a separate default communications headset) is
      * adopted as-is and must never be overwritten with the preferred endpoint.
      * @param preferred_id Endpoint device_id of the device to restore.
-     * @param steam_device_id The device ID of Steam Streaming Speakers.
+     * @param steam_device_id The Steam endpoint that initiated recovery.
      * @return success if every Steam-owned role was restored or released,
      *         no_device if the device isn't active right now, fatal if the
      *         policy call rejected it.
@@ -2190,13 +2367,21 @@ namespace platf::audio {
       const std::stop_token *stop_token = nullptr,
       const pending_restore_token_t &token = {}
     ) {
+      (void) steam_device_id;
+      const auto catalog = active_render_endpoint_catalog();
+      if (!catalog.complete) {
+        return reset_result_e::no_device;
+      }
+      const auto steam_device_ids = steam_render_device_ids(catalog);
+      const auto current_default_ids = current_default_device_ids();
+
       // Record which roles are actually on Steam before resolving anything.
       // Every other role belongs to the user and stays untouched by this
       // restore, exactly like the role-aware fallback reset.
       std::vector<ERole> steam_roles;
       for (int x = 0; x < (int) ERole_enum_count; ++x) {
         const auto role = static_cast<ERole>(x);
-        if (is_default_device(steam_device_id, role)) {
+        if (contains_device_id(steam_device_ids, current_default_ids[role_index(role)])) {
           steam_roles.push_back(role);
         }
       }
@@ -2224,6 +2409,10 @@ namespace platf::audio {
       }
 
       const auto &resolved_id = matched->second;
+      const auto eligible_preferred = active_non_steam_render_endpoint(catalog, {resolved_id});
+      if (!eligible_preferred || *eligible_preferred != resolved_id) {
+        return reset_result_e::no_device;
+      }
 
       int failure = 0;
       int restored = 0;
@@ -2231,7 +2420,8 @@ namespace platf::audio {
         // Re-check ownership immediately before writing. The user may have
         // moved this role while the preferred endpoint was re-enumerated, so
         // adopt that newer default instead of replacing it.
-        if (!is_default_device(steam_device_id, role)) {
+        const auto guarded_default_ids = current_default_device_ids();
+        if (!contains_device_id(steam_device_ids, guarded_default_ids[role_index(role)])) {
           const bool adopted =
             stop_token ?
               adopt_current_policy_endpoint_for_worker(token, assignment_epoch, role) :
@@ -2292,14 +2482,12 @@ namespace platf::audio {
     }
 
     /**
-     * @brief Attempts to move the default audio device away from Steam Streaming Speakers.
-     * Temporarily disables Steam speakers so the OS picks another default,
-     * then re-enables them and confirms the new default. Only the roles that are
-     * still assigned to Steam speakers are rewritten, and each of those roles is
-     * moved to the fallback Windows picked for that role. A role the user points
-     * at another endpoint (commonly a separate default communications headset)
-     * must never be overwritten with the playback fallback.
-     * @param steam_device_id The device ID of Steam Streaming Speakers.
+     * @brief Moves every Steam-owned default role to an active physical endpoint.
+     * Steam's full-duplex driver exposes both "Steam Streaming Speakers" and
+     * "Steam Streaming Microphone" as render endpoints. Explicitly selecting a
+     * catalog-proven non-Steam endpoint prevents Windows from promoting the
+     * microphone half during speaker teardown.
+     * @param steam_device_id The Steam endpoint that initiated recovery.
      * @return Result indicating success, retriable failure, or fatal failure.
      */
     reset_result_e try_reset_from_steam(
@@ -2314,39 +2502,27 @@ namespace platf::audio {
         return reset_result_e::inactive;
       }
 
-      // Record which roles are actually on Steam before hiding it. Every other
-      // role belongs to the user and stays untouched by this recovery.
+      (void) steam_device_id;
+      const auto catalog = active_render_endpoint_catalog();
+      if (!catalog.complete) {
+        return reset_result_e::no_device;
+      }
+      const auto steam_device_ids = steam_render_device_ids(catalog);
+      if (steam_device_ids.empty()) {
+        return reset_result_e::success;
+      }
+
+      const auto current_default_ids = current_default_device_ids();
       std::vector<ERole> steam_roles;
       for (int x = 0; x < (int) ERole_enum_count; ++x) {
         const auto role = static_cast<ERole>(x);
-        if (is_default_device(steam_device_id, role)) {
+        if (contains_device_id(steam_device_ids, current_default_ids[role_index(role)])) {
           steam_roles.push_back(role);
         }
       }
       if (steam_roles.empty()) {
         return reset_result_e::success;
       }
-
-      // Always issue the matching enable call, even when the hide call reports
-      // failure or the assignment is superseded while Windows is servicing it.
-      role_device_ids_t fallback_device_ids;
-      const auto hide_status =
-        policy->SetEndpointVisibility(steam_device_id.c_str(), FALSE);
-      if (SUCCEEDED(hide_status)) {
-        for (const auto role : steam_roles) {
-          auto new_default_dev = default_device(device_enum, role);
-          if (!new_default_dev) {
-            continue;
-          }
-
-          audio::wstring_t new_default_id;
-          if (SUCCEEDED(new_default_dev->GetId(&new_default_id)) && new_default_id) {
-            fallback_device_ids[role_index(role)] = new_default_id.get();
-          }
-        }
-      }
-      const auto show_status =
-        policy->SetEndpointVisibility(steam_device_id.c_str(), TRUE);
 
       const bool assignment_active =
         stop_token ?
@@ -2356,28 +2532,26 @@ namespace platf::audio {
         reassert_current_policy_assignment();
         return reset_result_e::inactive;
       }
-      if (FAILED(hide_status)) {
-        BOOST_LOG(warning) << "Failed to disable Steam audio device: "sv
-                           << util::hex(hide_status).to_string_view();
-        if (FAILED(show_status)) {
-          BOOST_LOG(warning) << "Failed to enable Steam audio device after the hide failure: "sv
-                             << util::hex(show_status).to_string_view();
-        }
-        return reset_result_e::fatal;
-      }
-      if (FAILED(show_status)) {
-        BOOST_LOG(warning) << "Failed to enable Steam audio device: "sv
-                           << util::hex(show_status).to_string_view();
-        return reset_result_e::fatal;
-      }
 
       bool no_device = false;
       int failure = 0;
       for (const auto role : steam_roles) {
-        // Windows may have kept the endpoint it selected while Steam was
-        // hidden, or the user may have picked another device. Adopt that newer
-        // default for this role instead of replacing it with the fallback.
-        if (!is_default_device(steam_device_id, role)) {
+        std::vector<std::wstring> preferred_ids {
+          captured_default_device_ids[role_index(role)],
+        };
+        if (const auto pending_id = pending_preferred_restore_id()) {
+          preferred_ids.push_back(*pending_id);
+        }
+        const auto fallback_device_id = active_non_steam_render_endpoint(catalog, preferred_ids);
+        if (!fallback_device_id) {
+          no_device = true;
+          continue;
+        }
+
+        // Check the live role again immediately before writing. A non-Steam
+        // endpoint is a newer user/system choice and must remain untouched.
+        const auto guarded_default_ids = current_default_device_ids();
+        if (!contains_device_id(steam_device_ids, guarded_default_ids[role_index(role)])) {
           const bool adopted =
             stop_token ?
               adopt_current_policy_endpoint_for_worker(token, assignment_epoch, role) :
@@ -2388,12 +2562,6 @@ namespace platf::audio {
           continue;
         }
 
-        const auto &new_default_id = fallback_device_ids[role_index(role)];
-        if (new_default_id.empty()) {
-          no_device = true;
-          continue;
-        }
-
         std::optional<HRESULT> result;
         if (stop_token) {
           result = set_default_endpoint_for_worker(
@@ -2401,13 +2569,13 @@ namespace platf::audio {
             token,
             assignment_epoch,
             role,
-            new_default_id
+            *fallback_device_id
           );
         } else {
           result = set_default_endpoint_for_assignment(
             assignment_epoch,
             role,
-            new_default_id
+            *fallback_device_id
           );
         }
         if (!result) {
@@ -2607,10 +2775,22 @@ namespace platf::audio {
         return reset_result_e::inactive;
       }
 
+      (void) steam_device_id;
+      const auto catalog = active_render_endpoint_catalog();
+      if (!catalog.complete) {
+        return reset_result_e::no_device;
+      }
+      const auto steam_device_ids = steam_render_device_ids(catalog);
+      if (steam_device_ids.empty()) {
+        return reset_result_e::success;
+      }
+
       std::vector<std::size_t> steam_role_indexes;
       for (std::size_t i = 0; i < role_restores.size(); ++i) {
         const auto &role_restore = role_restores[i];
-        if (role_restore.expected_current_id == steam_device_id && is_default_device(steam_device_id, role_restore.role)) {
+        const auto live_ids = current_default_device_ids();
+        if (contains_device_id(steam_device_ids, role_restore.expected_current_id) &&
+            contains_device_id(steam_device_ids, live_ids[role_index(role_restore.role)])) {
           steam_role_indexes.push_back(i);
         }
       }
@@ -2622,9 +2802,9 @@ namespace platf::audio {
         return reset_result_e::inactive;
       }
 
-      // Publish ownership of the whole visibility transition before Windows
-      // moves any role away from Steam. A new stream can then normalize the
-      // transferred record against the live fallback without waiting here.
+      // Publish ownership of the explicit fallback transition before policy
+      // writes begin. A new stream can then normalize the transferred record
+      // against the selected non-Steam endpoint without waiting here.
       for (const auto index : steam_role_indexes) {
         auto &role_restore = role_restores[index];
         role_restore.fallback_transition = true;
@@ -2637,45 +2817,9 @@ namespace platf::audio {
         }
       }
 
-      std::vector<std::wstring> fallback_device_ids(role_restores.size());
-      const auto hide_status =
-        policy->SetEndpointVisibility(steam_device_id.c_str(), FALSE);
-      if (SUCCEEDED(hide_status)) {
-        for (const auto index : steam_role_indexes) {
-          auto &role_restore = role_restores[index];
-          auto new_default_dev = default_device(device_enum, role_restore.role);
-          if (!new_default_dev) {
-            continue;
-          }
-
-          audio::wstring_t new_default_id;
-          if (SUCCEEDED(new_default_dev->GetId(&new_default_id)) && new_default_id) {
-            fallback_device_ids[index] = new_default_id.get();
-          }
-        }
-      }
-
-      // Always re-enable Steam after hiding it, even if cancellation races
-      // with the fallback or the hide call reports failure.
-      const auto show_status =
-        policy->SetEndpointVisibility(steam_device_id.c_str(), TRUE);
       if (!pending_restore_worker_can_write(stop_token, token, assignment_epoch)) {
         reassert_current_policy_assignment();
         return reset_result_e::inactive;
-      }
-      if (FAILED(hide_status)) {
-        BOOST_LOG(warning) << "Failed to disable Steam audio device: "sv
-                           << util::hex(hide_status).to_string_view();
-        if (FAILED(show_status)) {
-          BOOST_LOG(warning) << "Failed to enable Steam audio device after the hide failure: "sv
-                             << util::hex(show_status).to_string_view();
-        }
-        return reset_result_e::fatal;
-      }
-      if (FAILED(show_status)) {
-        BOOST_LOG(warning) << "Failed to enable Steam audio device: "sv
-                           << util::hex(show_status).to_string_view();
-        return reset_result_e::fatal;
       }
 
       bool no_device = false;
@@ -2686,41 +2830,12 @@ namespace platf::audio {
         }
 
         auto &role_restore = role_restores[index];
-        const auto &fallback_device_id = fallback_device_ids[index];
+        const auto fallback_device_id = active_non_steam_render_endpoint(
+          catalog,
+          {role_restore.preferred_id}
+        );
 
-        if (!is_default_device(steam_device_id, role_restore.role)) {
-          // Windows may have kept the endpoint it selected while Steam was
-          // hidden. Treat that as product-owned only when it is the exact
-          // candidate we observed; otherwise leave the newer default alone.
-          if (!fallback_device_id.empty() && is_default_device(fallback_device_id, role_restore.role)) {
-            role_restore.expected_current_id = fallback_device_id;
-            role_restore.fallback_transition = false;
-            if (!update_pending_role_restore_for_worker(
-                  role_restore,
-                  token,
-                  assignment_epoch)) {
-              reassert_current_policy_assignment_role(role_restore.role);
-              return reset_result_e::inactive;
-            }
-          } else {
-            if (!adopt_current_policy_endpoint_for_worker(
-                  token,
-                  assignment_epoch,
-                  role_restore.role)) {
-              return reset_result_e::inactive;
-            }
-            role_restore.expected_current_id.clear();
-            role_restore.fallback_transition = false;
-            clear_pending_role_restore_for_worker(
-              role_restore,
-              token,
-              assignment_epoch
-            );
-          }
-          continue;
-        }
-
-        if (fallback_device_id.empty()) {
+        if (!fallback_device_id) {
           role_restore.fallback_transition = false;
           if (!update_pending_role_restore_for_worker(
                 role_restore,
@@ -2733,9 +2848,10 @@ namespace platf::audio {
           continue;
         }
 
-        // Check the role again immediately before writing so a user change
-        // cannot be replaced by the fallback chosen for another role.
-        if (!is_default_device(steam_device_id, role_restore.role)) {
+        // Check the role again immediately before writing so a user-selected
+        // non-Steam endpoint cannot be replaced by our fallback.
+        const auto live_ids = current_default_device_ids();
+        if (!contains_device_id(steam_device_ids, live_ids[role_index(role_restore.role)])) {
           if (!adopt_current_policy_endpoint_for_worker(
                 token,
                 assignment_epoch,
@@ -2756,7 +2872,7 @@ namespace platf::audio {
           token,
           assignment_epoch,
           role_restore.role,
-          fallback_device_id
+          *fallback_device_id
         );
         if (!result) {
           return reset_result_e::inactive;
@@ -2778,7 +2894,7 @@ namespace platf::audio {
           continue;
         }
 
-        role_restore.expected_current_id = fallback_device_id;
+        role_restore.expected_current_id = *fallback_device_id;
         role_restore.fallback_transition = false;
         if (!update_pending_role_restore_for_worker(
               role_restore,
@@ -2837,6 +2953,12 @@ namespace platf::audio {
       bool retry_fallback_reset = true;
       while (pending_restore_worker_can_write(stop_token, token, assignment_epoch) &&
              !role_restores.empty()) {
+        const auto catalog = active_render_endpoint_catalog();
+        if (!catalog.complete) {
+          arrival_notifier.wait(cancel_event, 1000);
+          continue;
+        }
+        const auto steam_device_ids = steam_render_device_ids(catalog);
         bool needs_fallback = false;
         for (auto it = role_restores.begin(); it != role_restores.end();) {
           const auto result = try_restore_pending_role(
@@ -2861,7 +2983,7 @@ namespace platf::audio {
             // A direct restore can fail even after the endpoint is visible.
             // While the role is still product-owned Steam, fall back from it
             // instead of leaving that role stuck there.
-            if (it->expected_current_id != steam_device_id) {
+            if (!contains_device_id(steam_device_ids, it->expected_current_id)) {
               // Keep retrying a captured endpoint while the exact fallback we
               // selected remains active. Only a newer live choice releases it.
               if (is_default_device(it->expected_current_id, it->role)) {
@@ -2887,7 +3009,8 @@ namespace platf::audio {
             continue;
           }
 
-          needs_fallback = needs_fallback || it->expected_current_id == steam_device_id;
+          needs_fallback = needs_fallback ||
+                           contains_device_id(steam_device_ids, it->expected_current_id);
           ++it;
         }
 
@@ -2922,7 +3045,9 @@ namespace platf::audio {
         // Any role with a captured endpoint stays queued until that endpoint
         // returns, but only while its expected fallback remains selected.
         for (auto it = role_restores.begin(); it != role_restores.end();) {
-          if (it->expected_current_id.empty() || (it->preferred_id.empty() && it->expected_current_id != steam_device_id)) {
+          if (it->expected_current_id.empty() ||
+              (it->preferred_id.empty() &&
+               !contains_device_id(steam_device_ids, it->expected_current_id))) {
             clear_pending_role_restore_for_worker(
               *it,
               token,
@@ -2984,13 +3109,19 @@ namespace platf::audio {
         // modifying the default audio device or enumerating devices again.
         Sleep(5000);
 
-        // Restore only roles that Windows moved to the newly installed endpoint.
-        // Recheck immediately before each write so a concurrent user choice wins.
-        if (auto matched_steam = find_device_id(match_steam_speakers())) {
+        // Restore only roles that Windows moved to either render half of the
+        // newly installed Steam topology. Recheck immediately before each
+        // write so a concurrent user choice wins.
+        const auto catalog = active_render_endpoint_catalog();
+        if (catalog.complete) {
+          const auto steam_device_ids = steam_render_device_ids(catalog);
+          const auto current_ids = current_default_device_ids();
           for (int x = 0; x < static_cast<int>(ERole_enum_count); ++x) {
             const auto role = static_cast<ERole>(x);
             const auto &old_default_id = old_default_ids[role_index(role)];
-            if (old_default_id.empty() || !is_default_device(matched_steam->second, role)) {
+            if (old_default_id.empty() ||
+                contains_device_id(steam_device_ids, old_default_id) ||
+                !contains_device_id(steam_device_ids, current_ids[role_index(role)])) {
               continue;
             }
 

--- a/tests/unit/test_audio.cpp
+++ b/tests/unit/test_audio.cpp
@@ -47,6 +47,53 @@ TEST(AudioSinkPolicy, PreservesPriorityAndEmptyFallbacks) {
   EXPECT_TRUE(select_sink(no_virtual, "", 2, false).empty());
 }
 
+TEST(AudioEndpointRestorePolicy, ExcludesBothSteamRenderAdapters) {
+  const std::vector<render_endpoint_t> endpoints {
+    {"steam-speakers", "Steam Streaming Speakers", true},
+    {"steam-microphone", "Steam Streaming Microphone", true},
+    {"realtek", "Realtek USB Audio", true},
+  };
+
+  EXPECT_TRUE(is_steam_streaming_render_adapter("Steam Streaming Speakers"));
+  EXPECT_TRUE(is_steam_streaming_render_adapter("Steam Streaming Microphone"));
+  EXPECT_FALSE(is_steam_streaming_render_adapter("Steam Streaming Speakers 2"));
+  EXPECT_FALSE(is_steam_streaming_render_adapter("Realtek USB Audio"));
+  EXPECT_EQ(
+    select_eligible_non_steam_render_endpoint(endpoints, {"steam-microphone", "realtek"}),
+    std::optional<std::string> {"realtek"}
+  );
+}
+
+TEST(AudioEndpointRestorePolicy, PrefersActivePhysicalEndpointAndRejectsSteamOnlyCatalog) {
+  const std::vector<render_endpoint_t> endpoints {
+    {"steam-speakers", "Steam Streaming Speakers", true},
+    {"steam-microphone", "Steam Streaming Microphone", true},
+    {"inactive-realtek", "Realtek USB Audio", false},
+    {"hdmi", "NVIDIA High Definition Audio", true},
+  };
+
+  EXPECT_EQ(
+    select_eligible_non_steam_render_endpoint(endpoints, {"inactive-realtek", "hdmi"}),
+    std::optional<std::string> {"hdmi"}
+  );
+
+  const std::vector<render_endpoint_t> only_steam {
+    {"steam-speakers", "Steam Streaming Speakers", true},
+    {"steam-microphone", "Steam Streaming Microphone", true},
+  };
+  EXPECT_EQ(select_eligible_non_steam_render_endpoint(only_steam, {}), std::nullopt);
+}
+
+TEST(AudioEndpointRestorePolicy, IncompleteCatalogFailsClosed) {
+  const auto catalog = build_render_endpoint_catalog(false, {
+    {"steam-speakers", "Steam Streaming Speakers", true},
+    {"realtek", "Realtek USB Audio", true},
+  });
+
+  EXPECT_FALSE(catalog.complete);
+  EXPECT_EQ(select_eligible_non_steam_render_endpoint(catalog, {"realtek"}), std::nullopt);
+}
+
 namespace {
   class fake_source_t: public sample_source_t {
   public:


### PR DESCRIPTION
## What changed

- classify both Steam render endpoints (`Steam Streaming Speakers` and `Steam Streaming Microphone`) as the same product-owned audio topology
- restore each Steam-owned Windows audio role to an active non-Steam endpoint without hiding only one Steam endpoint
- prefer the captured physical endpoint when it is still active, while preserving newer user-selected role assignments
- fail closed and retry when endpoint discovery is incomplete

## Root cause

The Steam audio driver exposes both adapter halves as active render endpoints. Teardown hid only `Steam Streaming Speakers`, so Windows could promote the render half named `Steam Streaming Microphone` instead of returning to the original Realtek or other physical endpoint. That left the physical speakers unavailable as the selected output after a stream ended.

## User impact

After disconnecting a stream, Console, Multimedia, and Communications roles return to the captured active physical endpoint when they are still owned by the Steam topology. A user change made during teardown remains authoritative.

## Validation

- Windows `sunshine` target rebuilt successfully with warnings-as-errors enabled
- `test_component_audio_policy` passed
- `ctest -R ^test_component_audio_policy$ --output-on-failure` passed
- the Windows recovery path contains no `SetEndpointVisibility` calls