### PR TITLE
fix(input): send absolute mouse to the streamed monitor on Windows

### DIFF
--- a/src/mouse_input.cpp
+++ b/src/mouse_input.cpp
@@ -4,7 +4,24 @@
  */
 #include "mouse_input.h"
 
+#include <cmath>
+
 namespace mouse_input {
+  point_t to_virtual_desktop(const viewport_t &viewport, const absolute_position_t position) {
+    if (viewport.width <= 0 || viewport.height <= 0) {
+      return {0, 0};
+    }
+
+    const auto scale = [](const float value, const int span) {
+      return static_cast<int>(std::lround(value * (static_cast<float>(VIRTUAL_DESKTOP_GRID) / static_cast<float>(span))));
+    };
+
+    return {
+      scale(position.x + static_cast<float>(viewport.offset_x), viewport.width),
+      scale(position.y + static_cast<float>(viewport.offset_y), viewport.height)
+    };
+  }
+
   controller_t::controller_t(backend_t &backend):
       _backend(backend) {}
 

--- a/src/mouse_input.h
+++ b/src/mouse_input.h
@@ -26,6 +26,20 @@ namespace mouse_input {
     bool operator==(const absolute_position_t &) const = default;
   };
 
+  // Platforms that address the whole desktop with a fixed normalized grid, rather than
+  // in pixels, use this many steps per axis.
+  constexpr int VIRTUAL_DESKTOP_GRID = 65535;
+
+  /**
+   * @brief Map a monitor-local position onto the normalized virtual-desktop grid.
+   * @details The position is relative to the streamed monitor, so the monitor's own
+   * origin within the desktop has to be folded in before scaling. A viewport with no
+   * area maps to the origin rather than dividing by zero.
+   * @param viewport The desktop origin of the streamed monitor and the desktop's size.
+   * @param position The monitor-local position, in the viewport's own units.
+   */
+  point_t to_virtual_desktop(const viewport_t &viewport, absolute_position_t position);
+
   class backend_t {
   public:
     virtual ~backend_t() = default;

--- a/src/platform/windows/input.cpp
+++ b/src/platform/windows/input.cpp
@@ -22,6 +22,7 @@
 #include "src/config.h"
 #include "src/globals.h"
 #include "src/logging.h"
+#include "src/mouse_input.h"
 #include "src/platform/common.h"
 
 #ifdef __MINGW32__
@@ -34,13 +35,6 @@ namespace platf {
   using namespace std::literals;
 
   thread_local HDESK _lastKnownInputDesktop = nullptr;
-
-  constexpr touch_port_t target_touch_port {
-    0,
-    0,
-    65535,
-    65535
-  };
 
   using client_t = util::safe_ptr<_VIGEM_CLIENT_T, vigem_free>;
   using target_t = util::safe_ptr<_VIGEM_TARGET_T, vigem_target_free>;
@@ -550,13 +544,17 @@ namespace platf {
       // MOUSEEVENTF_VIRTUALDESK maps to the entirety of the desktop rather than the primary desktop
       MOUSEEVENTF_VIRTUALDESK;
 
-    // Note: x and y already include the display offset (offset_x/offset_y) from client_to_touchport(),
-    // so we must not add offset_x/offset_y again here to avoid double-offsetting on multi-monitor setups.
-    auto scaled_x = std::lround(x * ((float) target_touch_port.width / (float) touch_port.width));
-    auto scaled_y = std::lround(y * ((float) target_touch_port.height / (float) touch_port.height));
+    // x and y are relative to the streamed monitor: client_to_touchport() only folds the
+    // monitor origin in for the Linux backends, leaving Windows and macOS to apply it in
+    // platform code. MOUSEEVENTF_VIRTUALDESK addresses the whole desktop, so the origin
+    // has to be added back before scaling, or every non-primary monitor lands wrong.
+    const auto scaled = mouse_input::to_virtual_desktop(
+      {touch_port.offset_x, touch_port.offset_y, touch_port.width, touch_port.height},
+      {x, y}
+    );
 
-    mi.dx = scaled_x;
-    mi.dy = scaled_y;
+    mi.dx = scaled.x;
+    mi.dy = scaled.y;
 
     send_input(i);
   }

--- a/tests/unit/test_mouse.cpp
+++ b/tests/unit/test_mouse.cpp
@@ -73,3 +73,39 @@ TEST_P(MouseControllerTest, AbsoluteMoveForwardsViewportAndCoordinates) {
   EXPECT_EQ(backend.last_absolute, requested);
   EXPECT_EQ(backend.absolute_calls, 1);
 }
+
+// The virtual-desktop grid spans every monitor, but the position handed to a backend is
+// relative to the streamed monitor, so the monitor's origin has to be folded in first.
+// Dropping that term is what sent absolute mouse input to the wrong monitor.
+TEST(MouseVirtualDesktopMapping, AddsTheMonitorOriginBeforeScaling) {
+  const mouse_input::viewport_t viewport {2000, 0, 4000, 2000};
+
+  const auto mapped = mouse_input::to_virtual_desktop(viewport, {1000.0f, 500.0f});
+
+  // (1000 + 2000) / 4000 and 500 / 2000 of the grid.
+  EXPECT_EQ(mapped.x, 49151);
+  EXPECT_EQ(mapped.y, 16384);
+}
+
+TEST(MouseVirtualDesktopMapping, LeavesASingleMonitorDesktopAlone) {
+  const mouse_input::viewport_t viewport {0, 0, 4000, 2000};
+
+  const auto mapped = mouse_input::to_virtual_desktop(viewport, {1000.0f, 500.0f});
+
+  EXPECT_EQ(mapped.x, 16384);
+  EXPECT_EQ(mapped.y, 16384);
+}
+
+TEST(MouseVirtualDesktopMapping, HandlesAMonitorLeftOfThePrimary) {
+  // display_base_t reports offsets relative to the top-left of the virtual desktop, so a
+  // monitor left of the primary shows up at offset 0 with the primary pushed right.
+  const mouse_input::viewport_t viewport {0, 0, 4000, 2000};
+
+  EXPECT_EQ(mouse_input::to_virtual_desktop(viewport, {0.0f, 0.0f}).x, 0);
+  EXPECT_EQ(mouse_input::to_virtual_desktop({2000, 0, 4000, 2000}, {2000.0f, 0.0f}).x, mouse_input::VIRTUAL_DESKTOP_GRID);
+}
+
+TEST(MouseVirtualDesktopMapping, MapsAnEmptyViewportToTheOrigin) {
+  EXPECT_EQ(mouse_input::to_virtual_desktop({0, 0, 0, 0}, {10.0f, 10.0f}), (mouse_input::point_t {0, 0}));
+  EXPECT_EQ(mouse_input::to_virtual_desktop({0, 0, 1920, 0}, {10.0f, 10.0f}), (mouse_input::point_t {0, 0}));
+}


### PR DESCRIPTION
## Problem

Absolute mouse input aimed at a non-primary display lands on the wrong monitor.

`client_to_touchport()` returns a position relative to the **streamed monitor**, and folds the monitor origin in only for the Linux backends:

```cpp
// Linux input backends expect desktop-relative coordinates here.
// Windows/macOS apply monitor offsets in platform code, so adding offsets here
// would double-apply them and clamp input to edges.
#ifdef __linux__
  float final_x = (x + touch_port.offset_x * touch_port.scalar_tpcoords) / touch_port.scalar_tpcoords;
#else
  float final_x = x / touch_port.scalar_tpcoords;
#endif
```

macOS holds up its half of that contract, adding `CGDisplayBounds(display).origin` in `abs_mouse`. Windows stopped: `fe1c1f07` dropped the offset term and justified it with a note claiming the opposite of what the code above does.

```cpp
// Note: x and y already include the display offset (offset_x/offset_y) from client_to_touchport(),
// so we must not add offset_x/offset_y again here to avoid double-offsetting on multi-monitor setups.
auto scaled_x = std::lround(x * ((float) target_touch_port.width / (float) touch_port.width));
```

`MOUSEEVENTF_VIRTUALDESK` addresses the entire desktop, so every position was then interpreted relative to the desktop origin rather than the monitor's. The pointer tracks correctly only while the streamed monitor happens to sit at the top-left of the virtual desktop — which is why this went unnoticed on single-monitor hosts.

Concretely, streaming a 1920x1080 monitor whose origin is at `x = 1920` on a 3840-wide desktop: a click at the far right of the stream is sent to `1920 / 3840` of the desktop, landing in the middle of the *other* monitor.

## Fix

The mapping moves into `mouse_input` as `to_virtual_desktop()`, which is portable, unit-testable, and now the single definition of the 0..65535 grid — replacing the `target_touch_port` constant that only existed to carry it. Windows `abs_mouse` calls it. An empty viewport maps to the origin instead of dividing by zero.

The touch and pen paths are unaffected: they already apply the offset themselves in `populate_common_pointer_info`.

## Testing

Four cases in `tests/unit/test_mouse.cpp` (`test_component_mouse_policy`). Verified they fail against the pre-fix behaviour and pass after it:

```
[  FAILED  ] MouseVirtualDesktopMapping.AddsTheMonitorOriginBeforeScaling
[  FAILED  ] MouseVirtualDesktopMapping.HandlesAMonitorLeftOfThePrimary
```

Not yet exercised on hardware; it needs a Windows host with the streamed display placed somewhere other than the top-left of the desktop.

## Note

Touches lines adjacent to #455. They are independent and can merge in either order; the textual conflict in `abs_mouse`'s comment is a one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
